### PR TITLE
chore: ignore machine-local editor state, logs and env overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,12 @@ xy-shengsheng.pub
 node_modules/
 lib/
 *.tgz
+
+# Machine-local editor/tooling state (repo must be self-contained; a global
+# gitignore currently hides these on some machines only)
+.claude/
+
+# Logs and local environment overrides
+*.log
+.env
+.env.*.local


### PR DESCRIPTION
Keep the repo self-contained: .claude/ holds machine-local editor settings (previously only hidden by a global gitignore on some machines), and *.log/.env/.env.*.local guard against stray local state being committed.