### PR TITLE
Default quick-created tasks to backlog and empty descriptions to Write.

### DIFF
--- a/src/client/controller.ts
+++ b/src/client/controller.ts
@@ -44,14 +44,19 @@ export function paginateBoardColumn<T extends { readonly updatedAt: number; read
   }
 }
 
-/** Human quick-add from the web form: land in Todo so Overview and the board can show it. */
+/** Human quick-add from the web form: land in Backlog so drafts are not claimed. */
 export function humanQuickCreateRequest(projectId: string, title: string): {
   readonly projectId: string
   readonly title: string
   readonly creator: 'human:web-client'
-  readonly status: 'todo'
+  readonly status: 'backlog'
 } {
-  return { projectId, title: title.trim(), creator: 'human:web-client', status: 'todo' }
+  return { projectId, title: title.trim(), creator: 'human:web-client', status: 'backlog' }
+}
+
+/** Empty descriptions open Write; saved Markdown opens Preview. */
+export function descriptionComposerMode(description: string): 'write' | 'preview' {
+  return description.trim() === '' ? 'write' : 'preview'
 }
 
 /** Accept a create mutation result only when it carries a task id. */

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -15,7 +15,7 @@ import type { TaskboardSnapshot } from '../service/index.js'
 import {
   addWorkflowTab, copyWorkflowNode, insertWorkflowNode, moveWorkflowNode, removeWorkflowNode, removeWorkflowTab,
 } from '../workflow/index.js'
-import { applyAutomationDefaults, BOARD_COLUMN_PAGE_SIZE, boardDropIntent, createdTaskId, humanQuickCreateRequest, paginateBoardColumn, previewAutomationRuns, projectLabelCatalog, TaskboardClientController, tasksForLabel } from './controller.js'
+import { applyAutomationDefaults, BOARD_COLUMN_PAGE_SIZE, boardDropIntent, createdTaskId, descriptionComposerMode, humanQuickCreateRequest, paginateBoardColumn, previewAutomationRuns, projectLabelCatalog, TaskboardClientController, tasksForLabel } from './controller.js'
 import { PopoverShell, useExclusivePopover } from './popover.js'
 import { applyMarkdownEdit, parseMarkdown, type MarkdownBlock, type MarkdownEditAction, type MarkdownInline } from './markdown.js'
 import {
@@ -995,8 +995,8 @@ function TaskDetail({ project, task, tasks, workflows, detail, mutate, upload, d
   const [developmentBranch, setDevelopmentBranch] = useState(task.developmentContext?.branch ?? '')
   const [worktreePath, setWorktreePath] = useState(task.developmentContext?.kind === 'worktree' ? task.developmentContext.path : '')
   const [comment, setComment] = useState('')
-  const [descriptionMode, setDescriptionMode] = useState<'write' | 'preview'>('preview')
-  const [editingDescription, setEditingDescription] = useState(task.description.trim() === '')
+  const [descriptionMode, setDescriptionMode] = useState<'write' | 'preview'>(descriptionComposerMode(task.description))
+  const [editingDescription, setEditingDescription] = useState(true)
   const [commentMode, setCommentMode] = useState<'write' | 'preview'>('write')
   const [editingCommentId, setEditingCommentId] = useState<string>()
   const [editCommentBody, setEditCommentBody] = useState('')
@@ -1034,7 +1034,7 @@ function TaskDetail({ project, task, tasks, workflows, detail, mutate, upload, d
     setWorkflowId(task.workflowId ?? ''); setDevelopmentKind(task.developmentContext?.kind ?? ''); setDevelopmentBranch(task.developmentContext?.branch ?? '')
     setWorktreePath(task.developmentContext?.kind === 'worktree' ? task.developmentContext.path : '')
     setComment(''); setPendingAction(''); setActionReason(''); setConfirmDelete(false)
-    setDescriptionMode('preview'); setEditingDescription(task.description.trim() === ''); setCommentMode('write')
+    setDescriptionMode(descriptionComposerMode(task.description)); setEditingDescription(true); setCommentMode('write')
     setEditingCommentId(undefined); setEditCommentBody(''); setDeletingCommentId(undefined)
   }, [task.id])
   useEffect(() => { dialogRef.current?.focus() }, [task.id])

--- a/tests/client-route.spec.ts
+++ b/tests/client-route.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { applyAutomationDefaults, BOARD_COLUMN_PAGE_SIZE, classifyRevisionChange, createdTaskId, decodeTaskboardHash, encodeTaskboardRoute, boardDropIntent, humanQuickCreateRequest, paginateBoardColumn, previewAutomationRuns, projectLabelCatalog, renderTaskSessionDraft, restoreRecentProject, TaskboardClientController, tasksForLabel } from '../src/client/controller.js'
+import { applyAutomationDefaults, BOARD_COLUMN_PAGE_SIZE, classifyRevisionChange, createdTaskId, decodeTaskboardHash, descriptionComposerMode, encodeTaskboardRoute, boardDropIntent, humanQuickCreateRequest, paginateBoardColumn, previewAutomationRuns, projectLabelCatalog, renderTaskSessionDraft, restoreRecentProject, TaskboardClientController, tasksForLabel } from '../src/client/controller.js'
 import { taskboardStrings } from '../src/client/index.js'
 import { bindTaskboardLocale, currentTaskboardLanguage, formatAutomationLog, priorityLabel } from '../src/client/locales.js'
 
@@ -181,12 +181,19 @@ test('client copy selects complete Chinese and English labels from the Harness l
   assert.equal(formatAutomationLog(en, { kind: 'empty', message: 'worker concurrency is currently full', at: 1 }), 'Workers are busy; no new task was started')
 })
 
-test('human quick-add creates a Todo task and only treats a mutation result with an id as success', () => {
+test('empty task descriptions open the write tab and saved Markdown opens preview', () => {
+  assert.equal(descriptionComposerMode(''), 'write')
+  assert.equal(descriptionComposerMode('   \n\t  '), 'write')
+  assert.equal(descriptionComposerMode('Fill in the size.'), 'preview')
+  assert.equal(descriptionComposerMode('  already written  '), 'preview')
+})
+
+test('human quick-add creates a Backlog task and only treats a mutation result with an id as success', () => {
   assert.deepEqual(humanQuickCreateRequest('project-one', '  Wire the form  '), {
     projectId: 'project-one',
     title: 'Wire the form',
     creator: 'human:web-client',
-    status: 'todo',
+    status: 'backlog',
   })
   assert.equal(createdTaskId({ id: 'task-created', title: 'Wire the form' }), 'task-created')
   assert.equal(createdTaskId({ title: 'missing id' }), undefined)


### PR DESCRIPTION
New human-created tasks land in backlog so automation does not claim drafts early. Task detail opens Write when description is empty and Preview when content exists.