### PR TITLE
fix(taskboard): keep automation draining through claim races and clos…

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Use these constants. Read live values from disk; do not invent a different packa
 | Profile directory | `$DSH_HOME/profiles/<profile>` , usually `~/.dsh/profiles/web` |
 | Packed tarball name | `shengsheng-dsh-taskboard-<version>.tgz` |
 
-`<version>` comes from this repo's `package.json` (`0.1.0` at the time of writing). After `pnpm pack`, use the tarball that was actually written.
+`<version>` is whatever this repo's `package.json` currently declares — read it there rather than copying a number out of this document. After `pnpm pack`, use the tarball that was actually written.
 
 A longer copy-paste prompt for a Harness-side agent is in [docs/install-plugin-prompt.zh.md](docs/install-plugin-prompt.zh.md). The steps below are the normative English procedure.
 
@@ -104,7 +104,7 @@ Expected artifacts:
 Record the absolute tarball path. Example:
 
 ```text
-/absolute/path/to/DSH-taskboard/shengsheng-dsh-taskboard-0.1.0.tgz
+/absolute/path/to/DSH-taskboard/shengsheng-dsh-taskboard-<version>.tgz
 ```
 
 If this repository is already cloned and dependencies are installed, `pnpm build && pnpm pack` is enough. Optional local checks: `pnpm typecheck`, `pnpm test`, `pnpm example`.
@@ -114,7 +114,7 @@ If this repository is already cloned and dependencies are installed, `pnpm build
 The profile directory is a pnpm workspace root (`packages: [.]`). The `-w` / workspace-root flag is **mandatory**. Without it, pnpm fails with `ERR_PNPM_ADDING_TO_ROOT`.
 
 ```sh
-dsh plugin --profile web add -w /absolute/path/to/shengsheng-dsh-taskboard-0.1.0.tgz
+dsh plugin --profile web add -w /absolute/path/to/shengsheng-dsh-taskboard-<version>.tgz
 ```
 
 Prefer the packed tarball over the source directory. A source-directory add can miss `lib/` if the tree was not built.
@@ -269,7 +269,7 @@ Models must use the in-process tools. Do not shell out to `dsh-taskboard` from a
 | `taskboard_claim` | Claim one eligible `todo` with `expected_version` |
 | `taskboard_comment` | Append a Markdown comment |
 | `taskboard_submit_review` | Move owned `in_progress` work to `in_review` |
-| `taskboard_block` | Block with a concrete reason |
+| `taskboard_block` | Block the owned `in_progress` task with a concrete reason |
 | `taskboard_release_claim` | Release only the current Agent's claim |
 | `taskboard_relate` | Add `parent`, `blocks`, or `related` in the same project |
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -60,7 +60,7 @@ pnpm -v    # 11.x
 | Profile 目录 | `$DSH_HOME/profiles/<profile>`，通常是 `~/.dsh/profiles/web` |
 | 打包文件名 | `shengsheng-dsh-taskboard-<version>.tgz` |
 
-`<version>` 以本仓库 `package.json` 为准（撰写时为 `0.1.0`）。`pnpm pack` 之后使用实际生成的 tarball。
+`<version>` 以本仓库 `package.json` 当前声明的版本为准——去那里读，不要照抄本文里的数字。`pnpm pack` 之后使用实际生成的 tarball。
 
 给 Harness 内代理使用的一键粘贴提示词见 [docs/install-plugin-prompt.zh.md](docs/install-plugin-prompt.zh.md)。下面是规范安装步骤。
 
@@ -104,7 +104,7 @@ pnpm pack
 记下 tarball 的绝对路径，例如：
 
 ```text
-/absolute/path/to/DSH-taskboard/shengsheng-dsh-taskboard-0.1.0.tgz
+/absolute/path/to/DSH-taskboard/shengsheng-dsh-taskboard-<version>.tgz
 ```
 
 若仓库已经克隆且依赖已安装，执行 `pnpm build && pnpm pack` 即可。可选本地检查：`pnpm typecheck`、`pnpm test`、`pnpm example`。
@@ -114,7 +114,7 @@ pnpm pack
 profile 目录是 pnpm workspace 根（`packages: [.]`）。**必须**带 `-w`（workspace root）。不加时 pnpm 会报 `ERR_PNPM_ADDING_TO_ROOT`。
 
 ```sh
-dsh plugin --profile web add -w /absolute/path/to/shengsheng-dsh-taskboard-0.1.0.tgz
+dsh plugin --profile web add -w /absolute/path/to/shengsheng-dsh-taskboard-<version>.tgz
 ```
 
 优先安装打包后的 tarball，不要直接加源码目录。源码目录若未 build，会缺 `lib/`。
@@ -269,7 +269,7 @@ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3080/plugins/@shengshe
 | `taskboard_claim` | 用 `expected_version` 认领一条合格 `todo` |
 | `taskboard_comment` | 追加 Markdown 评论 |
 | `taskboard_submit_review` | 把持有的 `in_progress` 工作提交到 `in_review` |
-| `taskboard_block` | 用具体原因阻塞 |
+| `taskboard_block` | 用具体原因阻塞自己拥有的 `in_progress` 任务 |
 | `taskboard_release_claim` | 只释放当前 Agent 的认领 |
 | `taskboard_relate` | 在同一项目内添加 `parent`、`blocks` 或 `related` |
 

--- a/skills/manage-taskboard/SKILL.md
+++ b/skills/manage-taskboard/SKILL.md
@@ -21,7 +21,7 @@ Keep every write version-linear: after any successful comment, relation, block, 
 
 ## Handle exceptional outcomes
 
-- Call `taskboard_block` only with a concrete reason when work cannot proceed. Include the missing dependency, decision, permission, or external condition.
+- Call `taskboard_block` only on the in-progress task you hold the claim for, and only with a concrete reason when work cannot proceed. Include the missing dependency, decision, permission, or external condition. A `todo` you have not claimed is not yours to block: report the obstacle in a comment and leave the column to a human.
 - Call `taskboard_release_claim` when intentionally abandoning owned work. Explain what remains and leave useful progress in a comment first when possible.
 - Use `taskboard_relate` only after reading both tasks. Keep relations within one project and do not create parent cycles.
 - Never call or emulate acceptance. Only a human may accept `in_review` as `done`, return it for rework, approve backlog work, archive it, or permanently delete it.

--- a/src/automation/index.ts
+++ b/src/automation/index.ts
@@ -1,5 +1,5 @@
 import { TaskboardError } from '../domain/index.js'
-import type { AutomationRule, TaskboardTask } from '../domain/index.js'
+import type { AutomationDecision, AutomationRule, AutomationState, TaskboardTask } from '../domain/index.js'
 import type { TaskboardService } from '../service/index.js'
 
 export type QuotaState = 'available' | 'uncertain'
@@ -13,6 +13,12 @@ export interface TaskboardQuotaPolicy {
 }
 
 const DEFAULT_QUOTA: TaskboardQuotaPolicy = { state: () => Promise.resolve('available') }
+
+/** Claim failures that only mean "this candidate is taken", so the drain must try the next one.
+ *  Treating them as fatal used to abandon the rest of the queue for the whole round. */
+const CONTENDED_CLAIM_CODES: ReadonlySet<string> = new Set([
+  'TASK_INVALID_TRANSITION', 'TASK_ALREADY_CLAIMED', 'TASK_STALE_VERSION', 'TASK_DEVELOPMENT_CONTEXT_BUSY',
+])
 
 /** Host-owned durable scheduler that starts work but never steals an existing claim. */
 export class TaskboardAutomationCoordinator {
@@ -114,10 +120,32 @@ export class TaskboardAutomationCoordinator {
     this.draining.add(ruleId)
     this.cancelTimer(ruleId)
     const coordinatorActive = this.running
+    let failure: unknown
     try {
       await this.drain(ruleId, coordinatorActive)
+    } catch (error) {
+      failure = error
     } finally {
       this.draining.delete(ruleId)
+    }
+    // The timer was cancelled on entry, so a thrown drain used to leave the rule with no timer at
+    // all: it stopped being scheduled until an unrelated rescan or a Host restart. Record the
+    // failure and re-arm instead.
+    if (failure !== undefined) this.reschedule(ruleId, failure)
+  }
+
+  private reschedule(ruleId: string, failure: unknown): void {
+    if (!this.running) return
+    try {
+      const latest = this.taskboard.provider.getAutomation(ruleId)
+      if (latest.state !== 'enabled') return
+      this.schedule(this.record(ruleId, {
+        kind: 'error',
+        message: failure instanceof Error ? failure.message : String(failure),
+        at: Date.now(),
+      }, Date.now() + latest.config.intervalMs))
+    } catch (_ruleUnavailable) {
+      // The rule was deleted or disabled while draining; there is nothing left to schedule.
     }
   }
 
@@ -134,7 +162,7 @@ export class TaskboardAutomationCoordinator {
       if (!preserve && rule.state !== 'enabled') return
       const quota = await this.quota.state(rule)
       if (quota === 'uncertain' && rule.config.quotaPolicy === 'pause-on-uncertain') {
-        rule = this.taskboard.provider.recordAutomationDecision(rule.id, rule.version, {
+        rule = this.record(ruleId, {
           kind: 'quota-paused', message: 'quota state is uncertain; no new claims started', at: Date.now(),
         }, preserve ? kept : undefined, preserve ? undefined : 'paused')
         if (!preserve) this.refresh(rule)
@@ -144,7 +172,7 @@ export class TaskboardAutomationCoordinator {
       const slots = this.availableSlots(rule)
       if (slots === 0) {
         if (inFlight.size === 0) {
-          rule = this.taskboard.provider.recordAutomationDecision(rule.id, rule.version, {
+          rule = this.record(ruleId, {
             kind: 'empty', message: 'worker concurrency is currently full', at: Date.now(),
           }, preserve ? kept : Date.now() + rule.config.intervalMs)
           if (!preserve) this.schedule(rule)
@@ -160,7 +188,7 @@ export class TaskboardAutomationCoordinator {
           continue
         }
         const pause = !preserve && rule.config.autoPauseOnEmpty
-        rule = this.taskboard.provider.recordAutomationDecision(rule.id, rule.version, {
+        rule = this.record(ruleId, {
           kind: 'empty', message: 'no eligible todo tasks', at: Date.now(),
         }, preserve ? kept : (pause ? undefined : Date.now() + rule.config.intervalMs), pause ? 'paused' : preserve ? undefined : 'enabled')
         if (!preserve) this.schedule(rule)
@@ -168,16 +196,21 @@ export class TaskboardAutomationCoordinator {
       }
       let started = 0
       let dependencyBlocked = 0
+      let contended = 0
       for (const task of candidates) {
         if (started >= slots) break
         try {
           this.startWorker(rule, task)
           started += 1
-          rule = this.taskboard.provider.recordAutomationDecision(rule.id, rule.version, {
+          rule = this.record(ruleId, {
             kind: 'claimed', taskId: task.id, message: `worker started for ${task.identifier}`, at: Date.now(),
           }, preserve ? kept : undefined)
         } catch (error) {
-          if (error instanceof TaskboardError && error.code === 'TASK_DEPENDENCY_INCOMPLETE') dependencyBlocked += 1
+          if (!(error instanceof TaskboardError)) throw error
+          // Losing a candidate to a dependency, to another owner, or to a busy development context
+          // says nothing about the rest of the queue. Only a genuine fault ends the round.
+          if (error.code === 'TASK_DEPENDENCY_INCOMPLETE') dependencyBlocked += 1
+          else if (CONTENDED_CLAIM_CODES.has(error.code)) contended += 1
           else throw error
         }
       }
@@ -186,9 +219,11 @@ export class TaskboardAutomationCoordinator {
         await Promise.race(inFlight)
         continue
       }
-      rule = this.taskboard.provider.recordAutomationDecision(rule.id, rule.version, {
+      rule = this.record(ruleId, {
         kind: dependencyBlocked > 0 ? 'dependency-blocked' : 'empty',
-        message: dependencyBlocked > 0 ? 'todo tasks are waiting for dependencies' : 'no worker started',
+        message: dependencyBlocked > 0
+          ? 'todo tasks are waiting for dependencies'
+          : contended > 0 ? 'every eligible todo is already owned elsewhere' : 'no worker started',
         at: Date.now(),
       }, preserve ? kept : Date.now() + rule.config.intervalMs)
       if (!preserve) this.schedule(rule)
@@ -226,12 +261,17 @@ export class TaskboardAutomationCoordinator {
       throw error
     }
     const ruleTracking = this.ruleInFlight(ruleId)
-    const tracked = run.catch(async (error: unknown) => {
-      const latest = this.taskboard.provider.getAutomation(rule.id)
-      if (latest.state === 'enabled') {
-        this.taskboard.provider.recordAutomationDecision(latest.id, latest.version, {
-          kind: 'error', taskId: task.id, message: error instanceof Error ? error.message : String(error), at: Date.now(),
-        }, latest.nextEligibleAt)
+    const tracked = run.catch((error: unknown) => {
+      try {
+        const latest = this.taskboard.provider.getAutomation(rule.id)
+        if (latest.state === 'enabled') {
+          this.record(ruleId, {
+            kind: 'error', taskId: task.id, message: error instanceof Error ? error.message : String(error), at: Date.now(),
+          }, latest.nextEligibleAt)
+        }
+      } catch (_bookkeepingFailed) {
+        // `drain()` awaits this promise. Letting the error log's own failure reject it turned one
+        // worker launch failure into a dead round for the whole rule.
       }
     }).finally(() => {
       this.inFlight.delete(tracked)
@@ -242,6 +282,19 @@ export class TaskboardAutomationCoordinator {
     })
     this.inFlight.add(tracked)
     ruleTracking.add(tracked)
+  }
+
+  /** Record a decision against the row's current version.
+   *  Workers settle while `drain()` awaits, so the version it read before an await is routinely
+   *  stale by the time it writes; a compare-and-set on that stale value threw out of the round. */
+  private record(
+    ruleId: string,
+    decision: AutomationDecision,
+    nextEligibleAt: number | undefined,
+    state?: AutomationState,
+  ): AutomationRule {
+    const latest = this.taskboard.provider.getAutomation(ruleId)
+    return this.taskboard.provider.recordAutomationDecision(latest.id, latest.version, decision, nextEligibleAt, state)
   }
 
   private decrement(projectId: string): void {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -75,6 +75,14 @@ function jsonOption<T>(options: ReadonlyMap<string, string>, name: string): T {
   }
 }
 
+/** A cast used to be the only gate here, so `--status done` reached the INSERT unchallenged. */
+function creationStatus(value: string): 'backlog' | 'todo' {
+  if (value !== 'backlog' && value !== 'todo') {
+    throw new TaskboardError(`task creation cannot start at ${value}`, 'TASK_INVALID_INPUT', { status: value })
+  }
+  return value
+}
+
 function human(options: ReadonlyMap<string, string>): HumanActor {
   return { kind: 'human', actorId: options.get('actor') ?? 'human:cli' }
 }
@@ -184,7 +192,7 @@ export function runTaskboardCli(argv: readonly string[], io: CliIo): number {
             title: required(options, 'title'),
             creator: options.get('creator') ?? actor.actorId,
             ...(options.has('description') ? { description: required(options, 'description') } : {}),
-            ...(options.has('status') ? { status: required(options, 'status') as 'backlog' | 'todo' } : {}),
+            ...(options.has('status') ? { status: creationStatus(required(options, 'status')) } : {}),
           }
       value = provider.createTask(request, actor)
     } else if (group === 'task' && command === 'update') {

--- a/src/client/controller.ts
+++ b/src/client/controller.ts
@@ -3,7 +3,7 @@ import type { RemoteResult } from '@deepseek-ai/dsh-typert-protocol'
 import type { TaskboardSnapshot } from '../service/index.js'
 import { TASK_STATUSES } from '../domain/index.js'
 import type {
-  TaskStatus, TaskboardChangeWatchResult, TaskboardRemoteMutationRequest, TaskboardRemoteMutationResult, TaskDetail,
+  TaskStatus, TaskboardChangeWatchResult, TaskboardRemoteMutationRequest, TaskboardRemoteMutationResult, TaskboardTask, TaskDetail,
 } from '../domain/index.js'
 
 export type TaskboardView = 'dashboard' | 'board' | 'list' | 'labels' | 'gantt' | 'workflows'
@@ -308,11 +308,19 @@ export function encodeTaskboardRoute(route: TaskboardRoute): string {
   return `#taskboard/${project}/${route.view}${task}`
 }
 
+function watcherId(): string {
+  const random = globalThis.crypto as { randomUUID?: () => string } | undefined
+  return random?.randomUUID?.() ?? `watcher-${String(Math.trunc(Math.random() * 1e12))}`
+}
+
 /** Browser-local page state and route codec; business state always comes from the Host. */
 export class TaskboardClientController {
   private route = parseRoute()
   private listeners = new Set<() => void>()
   private globalRevision: number | undefined
+  /** Identifies this page's long-poll loop so the Host can release a waiter this page abandoned:
+   *  an abort is local and never reaches the Host, so the old waiter held its slot until timeout. */
+  private readonly watcherId = watcherId()
 
   constructor(
     readonly connection: ConnectionHandle,
@@ -394,11 +402,16 @@ export class TaskboardClientController {
     return JSON.parse(carried.value.valueJson ?? 'null') as unknown
   }
 
+  /** Search the whole project in SQLite. The board can only filter the tasks a snapshot carried. */
+  async searchTasks(projectId: string, search: string, signal?: AbortSignal): Promise<TaskboardTask[]> {
+    return await this.mutate('task.search', { projectId, search }, signal) as TaskboardTask[]
+  }
+
   async watchChanges(afterRevision: number, signal?: AbortSignal): Promise<TaskboardChangeWatchResult> {
     signal?.throwIfAborted()
     const carried = await this.remote.mutate({
       endpoint: 'changes.watch',
-      payloadJson: JSON.stringify({ afterRevision, timeoutMs: 10_000 }),
+      payloadJson: JSON.stringify({ afterRevision, timeoutMs: 10_000, watcherId: this.watcherId }),
     })
     signal?.throwIfAborted()
     if (!carried.ok) throw new Error(carried.error.message)

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -7,8 +7,8 @@ import type { PropsRuntime } from '@deepseek-ai/dsh-client-ui-slots'
 import type {} from '@deepseek-ai/dsh-client-ui-layout/client'
 import type {} from '@deepseek-ai/dsh-client-ui-sidebar/client'
 import type {
-  AutomationRule, AutomationRun, SavedWorkflow, TaskboardProject, TaskboardTask, TaskDetail as TaskDetailData,
-  WorkflowDocument,
+  AutomationRule, AutomationRun, SavedWorkflow, TaskboardChangeWatchResult, TaskboardProject, TaskboardTask,
+  TaskDetail as TaskDetailData, WorkflowDocument,
 } from '../domain/index.js'
 import { TASK_STATUSES } from '../domain/index.js'
 import type { TaskboardSnapshot } from '../service/index.js'
@@ -105,6 +105,19 @@ function actorInitial(value: string): string {
 
 function isClosedStatus(status: TaskboardTask['status']): boolean {
   return status === 'done' || status === 'canceled'
+}
+
+/** Backoff before the change poll is retried, and the idle delay before a truncated project's
+ *  search reaches SQLite. */
+const WATCH_RETRY_MS = 2_000
+const SEARCH_DEBOUNCE_MS = 250
+
+function pause(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise(resolve => {
+    const timer = window.setTimeout(() => { signal.removeEventListener('abort', onAbort); resolve() }, ms)
+    function onAbort(): void { window.clearTimeout(timer); resolve() }
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
 }
 
 const MARKDOWN_TOOLBAR: readonly { action: MarkdownEditAction; label: 'mdHeading' | 'mdBold' | 'mdItalic' | 'mdQuote' | 'mdCode' | 'mdLink' | 'mdBullet' | 'mdNumber'; glyph: string }[] = [
@@ -273,6 +286,9 @@ export function TaskboardPage({ controller, workspaces }: PageProps) {
   const [error, setError] = useState<string>()
   const [refreshKey, setRefreshKey] = useState(0)
   const [query, setQuery] = useState('')
+  /** Matches from SQLite for a project whose snapshot was truncated; the in-memory filter below
+   *  can only ever see the rows the snapshot carried. */
+  const [searchHits, setSearchHits] = useState<readonly TaskboardTask[]>([])
   const [statusFilter, setStatusFilter] = useState<string>('all')
   const [logOpen, setLogOpen] = useState(false)
   const [undo, setUndo] = useState<{ endpoint: string; payload: Record<string, unknown> }>()
@@ -332,7 +348,17 @@ export function TaskboardPage({ controller, workspaces }: PageProps) {
     const watch = async (): Promise<void> => {
       let revision = snapshot.globalRevision
       while (!abort.signal.aborted) {
-        const result = await controller.watchChanges(revision, abort.signal)
+        let result: TaskboardChangeWatchResult
+        try {
+          result = await controller.watchChanges(revision, abort.signal)
+        } catch (cause) {
+          if (abort.signal.aborted) return
+          setError(cause instanceof Error ? cause.message : String(cause))
+          // Leaving the loop here left the page on the 15s periodic refetch until the revision
+          // happened to move, which is exactly when it could not move on its own.
+          await pause(WATCH_RETRY_MS, abort.signal)
+          continue
+        }
         if (abort.signal.aborted) return
         if (result.changed || result.globalRevision !== revision) {
           // A local mutation already refreshes on its own. Without this guard its committed
@@ -343,11 +369,27 @@ export function TaskboardPage({ controller, workspaces }: PageProps) {
         revision = result.globalRevision
       }
     }
-    void watch().catch((cause: unknown) => {
-      if (!abort.signal.aborted) setError(cause instanceof Error ? cause.message : String(cause))
-    })
+    void watch()
     return () => { abort.abort() }
   }, [controller, route.open, snapshot?.globalRevision])
+
+  // Only a truncated project needs SQLite: otherwise the snapshot already holds every task the
+  // in-memory filter below could match.
+  useEffect(() => {
+    const needle = query.trim()
+    const projectId = route.projectId
+    if (!route.open || snapshot?.tasksTruncated !== true || needle === '' || projectId === undefined) {
+      setSearchHits([])
+      return
+    }
+    const abort = new AbortController()
+    const timer = window.setTimeout(() => {
+      controller.searchTasks(projectId, needle, abort.signal).then(hits => {
+        if (!abort.signal.aborted) setSearchHits(hits)
+      }, () => { /* the local filter still answers for everything the snapshot holds */ })
+    }, SEARCH_DEBOUNCE_MS)
+    return () => { abort.abort(); window.clearTimeout(timer) }
+  }, [controller, query, route.open, route.projectId, snapshot?.tasksTruncated, refreshKey])
 
   useEffect(() => {
     if (!route.open) return
@@ -379,13 +421,19 @@ export function TaskboardPage({ controller, workspaces }: PageProps) {
   if (!route.open) return null
   const selected = snapshot?.projects.find(project => project.id === route.projectId) ?? snapshot?.projects[0]
   const tasks = snapshot?.tasks ?? []
-  const visibleTasks = tasks.filter(task => {
+  const searchable = searchHits.length === 0
+    ? tasks
+    : [...tasks, ...searchHits.filter(hit => !tasks.some(task => task.id === hit.id))]
+  const visibleTasks = searchable.filter(task => {
     if (statusFilter !== 'all' && task.status !== statusFilter) return false
     const needle = query.trim().toLocaleLowerCase()
     return needle === ''
       || `${task.identifier} ${task.title} ${task.description} ${task.labels.join(' ')}`.toLocaleLowerCase().includes(needle)
   })
+  // A deep link can name a task the snapshot never carried. The detail fetch is keyed on
+  // route.taskId alone, so open the dialog on whichever of the two resolved it.
   const selectedTask = tasks.find(task => task.id === route.taskId)
+    ?? (detail !== undefined && detail.task.id === route.taskId ? detail.task : undefined)
   const refresh = (): void => { setRefreshKey(value => value + 1) }
   const closeDetail = (): void => {
     detailDirty.current = false
@@ -1005,9 +1053,16 @@ function Gantt({ tasks, open }: { tasks: readonly TaskboardTask[]; open: (task: 
   const [zoom, setZoom] = useState<'month' | 'quarter' | 'year'>('quarter')
   const [showCompleted, setShowCompleted] = useState(false)
   const [anchor, setAnchor] = useState(() => Date.now())
+  const rows = useRef<HTMLDivElement>(null)
+  // The bars are a percentage of the middle grid column, so the "today" line has to be placed in
+  // that column's own pixels. Anchoring it to 50% of the whole component dropped it between the
+  // title column and the track.
+  const [todayLeft, setTodayLeft] = useState<number>()
   const days = zoom === 'month' ? 30 : zoom === 'quarter' ? 90 : 365
   const start = anchor - ((days / 2) * 86_400_000)
-  const point = (value: string | undefined, fallback: number): number => value === undefined ? fallback : new Date(`${value}T00:00:00`).getTime()
+  // Task dates are calendar days validated in UTC by the provider. Parsing them at local midnight
+  // shifted every bar a day west of UTC.
+  const point = (value: string | undefined, fallback: number): number => value === undefined ? fallback : new Date(`${value}T00:00:00Z`).getTime()
   const end = start + (days * 86_400_000)
   const dated = tasks.filter(task => {
     if (task.startDate === undefined && task.dueDate === undefined) return false
@@ -1018,14 +1073,29 @@ function Gantt({ tasks, open }: { tasks: readonly TaskboardTask[]; open: (task: 
     const taskEnd = Math.max(point(task.dueDate, taskStart + 86_400_000), taskStart + 86_400_000)
     return taskEnd >= start && taskStart <= end
   })
-  return <div className="dsh-taskboard-gantt"><header><button type="button" onClick={() => { setAnchor(Date.now()) }}>{t.today}</button><select aria-label={t.ganttZoom} value={zoom} onChange={event => { setZoom(event.target.value as typeof zoom) }}><option value="month">{t.days30}</option><option value="quarter">{t.days90}</option><option value="year">{t.oneYear}</option></select><label><input type="checkbox" checked={showCompleted} onChange={event => { setShowCompleted(event.target.checked) }} />{t.showCompleted}</label></header><div className="dsh-taskboard-today" style={{ left: '50%' }} aria-hidden="true" />{dated.length === 0 ? <div className="dsh-taskboard-empty">{t.noDatedTasks}</div> : dated.map(task => {
+  useEffect(() => {
+    const container = rows.current
+    if (container === null) return
+    const measure = (): void => {
+      const track = container.querySelector('.dsh-taskboard-gantt-track')
+      if (track === null) { setTodayLeft(undefined); return }
+      const trackBox = track.getBoundingClientRect()
+      const containerBox = container.getBoundingClientRect()
+      setTodayLeft(trackBox.left - containerBox.left + (trackBox.width / 2))
+    }
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(container)
+    return () => { observer.disconnect() }
+  }, [dated.length, zoom])
+  return <div className="dsh-taskboard-gantt"><header><button type="button" onClick={() => { setAnchor(Date.now()) }}>{t.today}</button><select aria-label={t.ganttZoom} value={zoom} onChange={event => { setZoom(event.target.value as typeof zoom) }}><option value="month">{t.days30}</option><option value="quarter">{t.days90}</option><option value="year">{t.oneYear}</option></select><label><input type="checkbox" checked={showCompleted} onChange={event => { setShowCompleted(event.target.checked) }} />{t.showCompleted}</label></header><div className="dsh-taskboard-gantt-rows" ref={rows}>{todayLeft !== undefined && <div className="dsh-taskboard-today" style={{ left: `${String(todayLeft)}px` }} aria-hidden="true" />}{dated.length === 0 ? <div className="dsh-taskboard-empty">{t.noDatedTasks}</div> : dated.map(task => {
     const taskStart = point(task.startDate, point(task.dueDate, anchor))
     const taskEnd = point(task.dueDate, taskStart + 86_400_000)
     const left = Math.max(0, Math.min(100, ((taskStart - start) / (days * 86_400_000)) * 100))
     const width = Math.max(1.5, Math.min(100 - left, ((Math.max(taskEnd, taskStart + 86_400_000) - taskStart) / (days * 86_400_000)) * 100))
     const repeat = task.recurrence === undefined ? '' : ` · ${task.recurrence.frequency}/${task.recurrence.interval}${task.recurrence.until === undefined ? '' : ` until ${task.recurrence.until}`}`
     return <button type="button" key={task.id} onClick={() => { open(task) }}><span>{task.identifier} · {task.title}</span><span className="dsh-taskboard-gantt-track"><i style={{ left: `${left}%`, width: `${width}%` }} /></span><small>{task.startDate ?? '…'} → {task.dueDate ?? '…'}{repeat}</small></button>
-  })}</div>
+  })}</div></div>
 }
 
 function WorkflowEditor({ project, workflows, catalog, capabilities, mutate }: {
@@ -1517,7 +1587,7 @@ ${NAV_STYLES}
 .dsh-taskboard-status-dot{display:inline-block;width:8px;height:8px;border-radius:50%;background:currentColor;color:var(--dsw-alias-label-tertiary,#81858c)}.dsh-taskboard-status-dot[data-status=todo],.dsh-taskboard-status-dot[data-status=done]{color:var(--dsw-alias-state-success-primary,#22c55e)}.dsh-taskboard-status-dot[data-status=in_progress]{color:var(--dsw-alias-state-warn-primary,#f59e0b)}.dsh-taskboard-status-dot[data-status=in_review]{color:var(--dsw-alias-state-business-primary,#4176e6)}.dsh-taskboard-status-dot[data-status=blocked]{color:var(--dsw-alias-state-error-primary,#ec1313)}.dsh-taskboard-status-dot[data-status=canceled]{color:var(--dsw-alias-label-caption,#adb2b8)}.dsh-taskboard-status-dot[data-status=backlog]{color:var(--dsw-alias-label-tertiary,#81858c)}
 .dsh-taskboard-card{width:100%;display:flex;flex-direction:column;align-items:flex-start;gap:4px;margin-bottom:8px;padding:12px 14px;text-align:left;border:1px solid var(--dsw-alias-border-l2,rgba(0,0,0,.1));border-radius:12px;background:var(--dsw-alias-bg-layer-3,#fff);min-height:0}.dsh-taskboard-card:hover{border-color:var(--dsw-alias-label-dimmed,#e1e5ee);background:var(--dsw-alias-bg-layer-2,#fff)}.dsh-taskboard-card strong{font-weight:500}.dsh-taskboard-card small,.dsh-taskboard-card span{color:var(--dsw-alias-label-secondary,#61666b)}.dsh-taskboard-more{width:100%;display:flex;align-items:center;justify-content:center;gap:4px;min-height:32px;margin-top:4px;padding:6px 8px;border:0;border-radius:12px;background:transparent;color:var(--dsw-alias-label-tertiary,#81858c)}.dsh-taskboard-more:hover{background:var(--dsw-alias-interactive-bg-hover,rgba(38,49,72,.06));color:var(--dsw-alias-label-secondary,#61666b)}.dsh-taskboard-more-label{font-size:12px;line-height:18px}.dsh-taskboard-other{margin-top:14px}.dsh-taskboard-other .dsh-taskboard-card{display:inline-flex;width:min(280px,100%);margin-right:8px}
 .dsh-taskboard-table-wrap{overflow:auto}.dsh-taskboard-table-wrap table{width:100%;border-collapse:collapse}.dsh-taskboard-table-wrap th,.dsh-taskboard-table-wrap td{padding:10px 12px;border-bottom:1px solid var(--dsw-alias-border-l1,rgba(0,0,0,.04));text-align:left}.dsh-taskboard-row-open{padding:0;border:0;background:transparent;color:var(--dsw-alias-link,#2563eb);font:inherit;text-align:left;cursor:pointer}.dsh-taskboard-row-open:hover{text-decoration:underline}.dsh-taskboard-table-wrap tbody tr:hover{background:var(--dsw-alias-interactive-bg-hover,rgba(38,49,72,.06))}.dsh-taskboard-table-wrap th button{border:0;background:transparent;font-weight:500;min-height:0;padding:0;border-radius:0}
-.dsh-taskboard-gantt{position:relative;display:flex;flex-direction:column;gap:8px}.dsh-taskboard-gantt>header{display:flex;align-items:center;gap:10px}.dsh-taskboard-gantt>header label{display:flex;align-items:center;gap:5px}.dsh-taskboard-gantt>button{display:grid;grid-template-columns:220px 1fr minmax(180px,auto);gap:12px;align-items:center;text-align:left;border:0;background:transparent;min-height:0;padding:8px 0;border-radius:0}.dsh-taskboard-gantt>button:hover{background:transparent}.dsh-taskboard-gantt-track{position:relative;display:block;height:16px;border-radius:8px;background:var(--dsw-specific-sidebar-fill,#f9fafb);overflow:hidden}.dsh-taskboard-gantt-track i{position:absolute;top:2px;display:block;height:12px;border-radius:6px;background:var(--dsw-alias-state-business-primary,#4176e6)}.dsh-taskboard-today{position:absolute;top:42px;bottom:0;width:1px;background:var(--dsw-alias-state-error-primary,#ec1313);opacity:.45;pointer-events:none}.dsh-taskboard-gantt small{color:var(--dsw-alias-label-secondary,#61666b)}
+.dsh-taskboard-gantt{display:flex;flex-direction:column;gap:8px}.dsh-taskboard-gantt>header{display:flex;align-items:center;gap:10px}.dsh-taskboard-gantt>header label{display:flex;align-items:center;gap:5px}.dsh-taskboard-gantt-rows{position:relative;display:flex;flex-direction:column}.dsh-taskboard-gantt-rows>button{display:grid;grid-template-columns:220px 1fr minmax(180px,auto);gap:12px;align-items:center;text-align:left;border:0;background:transparent;min-height:0;padding:8px 0;border-radius:0}.dsh-taskboard-gantt-rows>button:hover{background:transparent}.dsh-taskboard-gantt-track{position:relative;display:block;height:16px;border-radius:8px;background:var(--dsw-specific-sidebar-fill,#f9fafb);overflow:hidden}.dsh-taskboard-gantt-track i{position:absolute;top:2px;display:block;height:12px;border-radius:6px;background:var(--dsw-alias-state-business-primary,#4176e6)}.dsh-taskboard-today{position:absolute;top:0;bottom:0;width:1px;background:var(--dsw-alias-state-error-primary,#ec1313);opacity:.45;pointer-events:none}.dsh-taskboard-gantt small{color:var(--dsw-alias-label-secondary,#61666b)}
 .dsh-taskboard-dialog-backdrop{position:absolute;inset:0;z-index:8;display:flex;align-items:center;justify-content:center;padding:24px;background:var(--dsw-alias-bg-mask-1,rgba(0,0,0,.24));backdrop-filter:var(--dsw-mask-blur,blur(2px))}
 .dsh-taskboard-detail{width:min(1120px,100%);height:100%;box-sizing:border-box;display:flex;flex-direction:column;overflow:hidden;padding:0;border:1px solid var(--dsw-alias-border-inverted,transparent);border-radius:24px;background:var(--dsw-alias-bg-layer-2,#fff);box-shadow:var(--dsw-shadow-lv3,0 12px 32px rgba(0,0,0,.08));--dsh-scrollbar-thumb:var(--dsw-alias-scrollbar-bg-l2,#d4d4d4);--dsh-scrollbar-thumb-hover:var(--dsw-alias-scrollbar-hover-l2,#c4c4c4)}.dsh-taskboard-detail:focus{outline:none}
 .dsh-taskboard-detail-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;flex:none;padding:20px 16px 12px 24px;border-bottom:1px solid var(--dsw-alias-border-l1,rgba(0,0,0,.04))}.dsh-taskboard-detail-heading{min-width:0;flex:1;display:flex;flex-direction:column;gap:8px}.dsh-taskboard-detail-meta{display:flex;flex-wrap:wrap;align-items:center;gap:8px}.dsh-taskboard-detail-path{font-weight:500;color:var(--dsw-alias-label-primary,#0f1115)}.dsh-taskboard-detail-meta small{color:var(--dsw-alias-label-tertiary,#81858c)}.dsh-taskboard-detail input.dsh-taskboard-detail-title{width:100%;height:auto;min-height:36px;padding:4px 0;border:0;border-radius:0;background:transparent;font-size:20px;line-height:28px;font-weight:500}.dsh-taskboard-detail input.dsh-taskboard-detail-title:focus{border:0;box-shadow:none;outline:none}.dsh-taskboard-detail-author{display:flex;align-items:center;gap:8px;color:var(--dsw-alias-label-secondary,#61666b)}.dsh-taskboard-detail-author strong{color:var(--dsw-alias-label-primary,#0f1115);font-weight:500}.dsh-taskboard-detail-toolbar{display:flex;align-items:center;gap:8px;flex:none}

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -269,6 +269,8 @@ export interface TaskListFilter {
   readonly projectId: TaskboardProjectId
   readonly statuses?: readonly TaskStatus[]
   readonly includeArchived?: boolean
+  /** Return only archived rows, so a bounded snapshot can page live and archived work apart. */
+  readonly archivedOnly?: boolean
   readonly search?: string
   readonly limit?: number
   readonly offset?: number

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -43,6 +43,13 @@ function route(value: string | undefined): { provider: string; model: string } |
   return { provider: value.slice(0, at), model: value.slice(at + 1) }
 }
 
+/** Human edits that a working Session must re-read. These are the activity kinds the provider
+ *  actually writes: the listener used to test for a `task.commented` kind that nothing emits, so
+ *  every human comment on an in-progress task was dropped. */
+const FOLLOWUP_ACTIVITY_KINDS: ReadonlySet<string> = new Set([
+  'task.updated', 'comment.created', 'comment.updated', 'comment.deleted',
+])
+
 function withReasoning(selection: ModelSelection, reasoning: string | undefined): ModelSelection {
   if (reasoning === undefined) return selection
   return { ...selection, reasoningEffort: ReasoningEffortId(reasoning) }
@@ -252,25 +259,47 @@ export class HarnessTaskboardWorker implements TaskboardAutomationWorker {
     if (task.status !== 'in_progress') return
     const rule = this.taskboard.provider.getAutomation(claim.automationId)
     const owner = actor(rule, claim)
-    if (goal.phase === 'complete') {
-      this.taskboard.provider.submitReview(
-        task.id, task.version,
-        'Completed',
-        completionResultComment(this.taskboard.provider.getTaskDetail(task.id).comments),
-        owner,
-      )
-    } else if (goal.phase === 'blocked') {
-      this.taskboard.provider.block(task.id, task.version, goal.blockedReason?.message ?? 'Harness Goal blocked', owner)
-    } else {
-      return
+    if (goal.phase !== 'complete' && goal.phase !== 'blocked') return
+    try {
+      if (goal.phase === 'complete') {
+        this.taskboard.provider.submitReview(
+          task.id, task.version,
+          'Completed',
+          completionResultComment(this.taskboard.provider.getTaskDetail(task.id).comments),
+          owner,
+        )
+      } else {
+        // A Goal can report a blank reason, and an empty blocker used to throw TASK_INVALID_INPUT
+        // straight out of the Host's event dispatch.
+        const reason = goal.blockedReason?.message?.trim() ?? ''
+        this.taskboard.provider.block(task.id, task.version, reason === '' ? 'Harness Goal blocked' : reason, owner)
+      }
+    } catch (error) {
+      // The Goal is over but the authoritative task disagrees. Leave it observable instead of
+      // throwing into the listener chain, and still let go of the Session below.
+      this.recordGoalFailure(rule, task, error)
     }
     // Review submission and blocking both retire the claim, so this worker is done with the Session.
     void this.releaseUnclaimed(claim.sessionId)
   }
 
+  private recordGoalFailure(rule: AutomationRule, task: TaskboardTask, error: unknown): void {
+    try {
+      const latest = this.taskboard.provider.getAutomation(rule.id)
+      this.taskboard.provider.recordAutomationDecision(latest.id, latest.version, {
+        kind: 'error',
+        taskId: task.id,
+        message: `Goal handoff failed: ${error instanceof Error ? error.message : String(error)}`,
+        at: Date.now(),
+      }, latest.nextEligibleAt)
+    } catch (_ruleUnavailable) {
+      // Nothing durable left to annotate; the listener still must not throw.
+    }
+  }
+
   private onTaskChanged(event: TaskboardChangeEvent): void {
     if (event.actorKind !== 'human' || event.taskId === undefined
-      || (event.activityKind !== 'task.updated' && event.activityKind !== 'task.commented')) return
+      || event.activityKind === undefined || !FOLLOWUP_ACTIVITY_KINDS.has(event.activityKind)) return
     const claim = this.taskboard.provider.listClaims(['active'])
       .find(item => item.taskId === event.taskId)
     if (claim === undefined) return

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,9 +71,15 @@ export function apply(ctx: Context, config: Config): void {
     service.bindAutomation(automation)
     nativeCtx.effect(() => {
       let stopping = false
+      // Orphan reconciliation is best effort. Binding the scheduler to its success meant one
+      // transient failure (agents service not ready, SQLite momentarily locked) left this Host
+      // process with no automation timer at all until a restart.
       void worker.reconcile().then(
         () => { if (!stopping) automation.start() },
-        error => { nativeCtx.logger.warn(`taskboard startup reconciliation failed: ${String(error)}`) },
+        error => {
+          nativeCtx.logger.warn(`taskboard startup reconciliation failed: ${String(error)}`)
+          if (!stopping) automation.start()
+        },
       )
       return async () => {
         stopping = true

--- a/src/service/attachments.ts
+++ b/src/service/attachments.ts
@@ -81,6 +81,14 @@ export class TaskboardAttachmentRoutes {
       this.reply(response, 404, { error: 'not found' })
       return
     }
+    // Check the method before spending the capability. Consuming first meant a stray GET on an
+    // upload URL, a preflight OPTIONS, or a retry with the wrong verb burned the single-use ticket
+    // and forced the client to mint a new one against a possibly newer task version.
+    const method = operation === 'upload' ? 'PUT' : 'GET'
+    if (request.method !== method) {
+      this.reply(response, 405, { error: `method must be ${method}` })
+      return
+    }
     const ticket = this.consume(token)
     if (ticket === undefined || ticket.kind !== operation) {
       this.reply(response, 404, { error: 'ticket is invalid or expired' })
@@ -100,10 +108,6 @@ export class TaskboardAttachmentRoutes {
   }
 
   private async upload(request: IncomingMessage, response: ServerResponse, ticket: UploadTicket): Promise<void> {
-    if (request.method !== 'PUT') {
-      this.reply(response, 405, { error: 'method must be PUT' })
-      return
-    }
     const declared = Number(request.headers['content-length'] ?? 0)
     const limit = this.provider.attachmentOptions.maxAttachmentBytes
     if (Number.isFinite(declared) && declared > limit) {
@@ -126,11 +130,7 @@ export class TaskboardAttachmentRoutes {
     this.reply(response, 201, created)
   }
 
-  private async download(request: IncomingMessage, response: ServerResponse, ticket: DownloadTicket): Promise<void> {
-    if (request.method !== 'GET') {
-      this.reply(response, 405, { error: 'method must be GET' })
-      return
-    }
+  private async download(_request: IncomingMessage, response: ServerResponse, ticket: DownloadTicket): Promise<void> {
     // Resolve and validate before writing the head, then stream: a 25MB attachment should not be
     // held in memory in full just to be handed to the socket.
     const opened = this.provider.openAttachment(ticket.attachmentId, ticket.disposition)

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -79,6 +79,26 @@ export interface TaskboardSnapshot {
 
 type RpcPayload = Record<string, unknown>
 
+/** Archived rows a snapshot carries for the dashboard's history section, budgeted separately from
+ *  the live board so one cannot starve the other. */
+const ARCHIVED_SNAPSHOT_LIMIT = 200
+
+interface TaskboardRpcFailure {
+  readonly code: string
+  readonly message: string
+  readonly details: Record<string, unknown>
+}
+
+/** Keep the domain code intact so a version conflict, a validation error, and a real fault stay
+ *  distinguishable. The Host's own `RpcError.code` union is closed and has no Taskboard member, so
+ *  only the Typert protocol below can report the code as a code. */
+function taskboardFailure(error: unknown): TaskboardRpcFailure {
+  if (error instanceof TaskboardError) {
+    return { code: error.code, message: error.message, details: error.details ?? {} }
+  }
+  return { code: 'internal', message: error instanceof Error ? error.message : String(error), details: {} }
+}
+
 function record(value: unknown, label: string): RpcPayload {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     throw new TaskboardError(`${label} must be an object`, 'TASK_INVALID_INPUT')
@@ -200,6 +220,7 @@ export class TaskboardService extends TypertRemoteService {
     readonly afterRevision: number
     readonly timer: ReturnType<typeof setTimeout>
     readonly resolve: (result: TaskboardChangeWatchResult) => void
+    readonly watcherId?: string
   }>()
   private lastRevision = 0
   private acceptingChangeWatches = true
@@ -315,18 +336,24 @@ export class TaskboardService extends TypertRemoteService {
     // the whole snapshot -- fall back to the first project so the page stays usable.
     const requested = projectId !== undefined && projects.some(project => project.id === projectId) ? projectId : undefined
     const selected = requested ?? projects[0]?.id
-    const filter = { includeArchived: true } as const
-    const tasks = selected === undefined
+    // Live and archived work are paged apart. Sharing one budget let a large archive push the
+    // board's own cards out of the snapshot and leave nothing but a truncation notice.
+    const live = selected === undefined
       ? []
-      : this.provider.listTasks({ projectId: selected, ...filter, limit: this.config.snapshotTaskLimit })
-    const taskTotal = selected === undefined ? 0 : this.provider.countTasks({ projectId: selected, ...filter })
+      : this.provider.listTasks({ projectId: selected, limit: this.config.snapshotTaskLimit })
+    const archived = selected === undefined
+      ? []
+      : this.provider.listTasks({ projectId: selected, archivedOnly: true, limit: ARCHIVED_SNAPSHOT_LIMIT })
+    const liveTotal = selected === undefined ? 0 : this.provider.countTasks({ projectId: selected })
+    const archivedTotal = selected === undefined ? 0 : this.provider.countTasks({ projectId: selected, archivedOnly: true })
+    const tasks = [...live, ...archived]
     return {
       schemaVersion: 1,
       globalRevision: this.provider.globalRevision(),
       projects,
       tasks,
-      taskTotal,
-      tasksTruncated: taskTotal > tasks.length,
+      taskTotal: liveTotal + archivedTotal,
+      tasksTruncated: live.length < liveTotal || archived.length < archivedTotal,
       workflows: selected === undefined ? [] : this.provider.listWorkflows(selected),
       automations: selected === undefined ? [] : this.provider.listAutomations(selected),
       automationRuns: selected === undefined ? [] : this.provider.listAutomationRuns(selected),
@@ -366,6 +393,7 @@ export class TaskboardService extends TypertRemoteService {
         const result = await this.watchChanges(
           nonNegativeInteger(input['afterRevision'], 'afterRevision'),
           integer(input['timeoutMs'], 'timeoutMs'),
+          input['watcherId'] === undefined ? undefined : string(input['watcherId'], 'watcherId'),
         )
         return { ok: true, valueJson: JSON.stringify(result) }
       } catch (error) {
@@ -374,20 +402,24 @@ export class TaskboardService extends TypertRemoteService {
       }
     }
     if (request.endpoint === 'automation.run-now') {
-      const result = await this.dispatchAutomationRunNow(payload)
-      if (!result.ok) return { ok: false, errorCode: result.error.code, errorMessage: result.error.message }
+      const result = await this.dispatchAutomationRunNowFailable(payload)
+      if (!result.ok) return { ok: false, errorCode: result.failure.code, errorMessage: result.failure.message }
       return { ok: true, valueJson: JSON.stringify(result.value ?? null) }
     }
-    const result = this.dispatchHumanRpc(request.endpoint, payload, human('human:web-client'))
-    if (!result.ok) return { ok: false, errorCode: result.error.code, errorMessage: result.error.message }
+    const result = this.dispatchHumanFailable(request.endpoint, payload, human('human:web-client'))
+    if (!result.ok) return { ok: false, errorCode: result.failure.code, errorMessage: result.failure.message }
     return { ok: true, valueJson: JSON.stringify(result.value ?? null) }
   }
 
-  /** Wait for a committed revision change without requiring a Harness event extension. */
-  watchChanges(afterRevision: number, timeoutMs: number): Promise<TaskboardChangeWatchResult> {
+  /** Wait for a committed revision change without requiring a Harness event extension.
+   *  `watcherId` identifies one long-poll loop. A client abort cannot reach the Host, so the
+   *  abandoned waiter used to hold its slot for the full timeout; a fresh watch from the same
+   *  watcher now settles the one it replaces. */
+  watchChanges(afterRevision: number, timeoutMs: number, watcherId?: string): Promise<TaskboardChangeWatchResult> {
     const boundedTimeout = Math.min(Math.max(timeoutMs, 1), this.config.maxChangeWatchMs)
     const current = this.provider.globalRevision()
     this.lastRevision = current
+    if (watcherId !== undefined) this.settleReplacedWatcher(watcherId, current)
     if (!this.acceptingChangeWatches || current !== afterRevision) {
       return Promise.resolve({ globalRevision: current, changed: current !== afterRevision })
     }
@@ -404,35 +436,54 @@ export class TaskboardService extends TypertRemoteService {
           resolve({ globalRevision, changed: globalRevision !== afterRevision })
         }, boundedTimeout),
         resolve,
+        ...(watcherId === undefined ? {} : { watcherId }),
       }
       this.changeWaiters.add(waiter)
     })
   }
 
-  /** Dispatch a loopback-authenticated direct UI intent. */
+  private settleReplacedWatcher(watcherId: string, globalRevision: number): void {
+    for (const waiter of [...this.changeWaiters]) {
+      if (waiter.watcherId !== watcherId) continue
+      this.changeWaiters.delete(waiter)
+      clearTimeout(waiter.timer)
+      waiter.resolve({ globalRevision, changed: false })
+    }
+  }
+
+  /** Dispatch a loopback-authenticated direct UI intent.
+   *  The Host error union cannot name a Taskboard code, so it rides in the message on this path. */
   dispatchHumanRpc(endpoint: string, payload: unknown, actor: HumanActor): RpcResult<unknown> {
+    const result = this.dispatchHumanFailable(endpoint, payload, actor)
+    if (result.ok) return { ok: true, value: result.value }
+    return { ok: false, error: { code: 'internal', message: `${result.failure.code}: ${result.failure.message}`, details: {} } }
+  }
+
+  private dispatchHumanFailable(
+    endpoint: string, payload: unknown, actor: HumanActor,
+  ): { ok: true; value: unknown } | { ok: false; failure: TaskboardRpcFailure } {
     try {
       const input = record(payload, 'RPC payload')
-      const value = this.dispatchHuman(endpoint, input, actor)
-      return { ok: true, value }
+      return { ok: true, value: this.dispatchHuman(endpoint, input, actor) }
     } catch (error) {
-      const message = error instanceof TaskboardError
-        ? `${error.code}: ${error.message}`
-        : error instanceof Error ? error.message : String(error)
-      return { ok: false, error: { code: 'internal', message, details: {} } }
+      return { ok: false, failure: taskboardFailure(error) }
     }
   }
 
   private async dispatchAutomationRunNow(payload: unknown): Promise<RpcResult<unknown>> {
+    const result = await this.dispatchAutomationRunNowFailable(payload)
+    if (result.ok) return { ok: true, value: result.value }
+    return { ok: false, error: { code: 'internal', message: `${result.failure.code}: ${result.failure.message}`, details: {} } }
+  }
+
+  private async dispatchAutomationRunNowFailable(
+    payload: unknown,
+  ): Promise<{ ok: true; value: unknown } | { ok: false; failure: TaskboardRpcFailure }> {
     try {
       const input = record(payload, 'RPC payload')
-      const value = await this.runAutomationNow(string(input['automationId'], 'automationId'))
-      return { ok: true, value }
+      return { ok: true, value: await this.runAutomationNow(string(input['automationId'], 'automationId')) }
     } catch (error) {
-      const message = error instanceof TaskboardError
-        ? `${error.code}: ${error.message}`
-        : error instanceof Error ? error.message : String(error)
-      return { ok: false, error: { code: 'internal', message, details: {} } }
+      return { ok: false, failure: taskboardFailure(error) }
     }
   }
 
@@ -457,6 +508,14 @@ export class TaskboardService extends TypertRemoteService {
         return this.provider.createTask(record(input['request'], 'request') as unknown as CreateTaskRequest, actor)
       case 'task.detail':
         return this.taskDetail(this.taskId(input))
+      case 'task.search':
+        // The board filters the snapshot in memory, which cannot see past its own limit.
+        return this.provider.listTasks({
+          projectId: ProjectId(string(input['projectId'], 'projectId')),
+          search: string(input['search'], 'search'),
+          includeArchived: true,
+          limit: this.config.snapshotTaskLimit,
+        })
       case 'task.update':
         return this.provider.updateTask(
           TaskId(string(input['taskId'], 'taskId')),

--- a/src/sqlite/provider.ts
+++ b/src/sqlite/provider.ts
@@ -407,7 +407,13 @@ export class SqliteTaskboardProvider {
   createTask(request: CreateTaskRequest, actor: TaskboardActor): TaskboardTask {
     const title = requiredText(request.title, 'task title')
     const creator = requiredText(request.creator, 'task creator')
-    if (request.status === 'todo') requireHuman(actor, 'approve task at creation')
+    // The table CHECK accepts all seven statuses, so an unvalidated RPC or CLI payload could open a
+    // task straight at `done` or `in_progress` and skip the human-owned lifecycle entirely.
+    const status = request.status ?? 'backlog'
+    if (status !== 'backlog' && status !== 'todo') {
+      throw new TaskboardError(`task creation cannot start at ${String(status)}`, 'TASK_INVALID_INPUT', { status })
+    }
+    if (status === 'todo') requireHuman(actor, 'approve task at creation')
     this.validateDevelopmentContext(request.developmentContext)
     this.validateTaskFields(request)
     const taskId = TaskId(id('task'))
@@ -422,7 +428,7 @@ export class SqliteTaskboardProvider {
           development_context_json, source_json, archived_at, version, created_at, updated_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, 1, ?, ?)
       `).run(
-        taskId, request.projectId, identifier, title, request.description ?? '', request.status ?? 'backlog',
+        taskId, request.projectId, identifier, title, request.description ?? '', status,
         request.priority ?? 'none', json(request.labels ?? []), request.sortOrder ?? project.nextIssueNumber * 1000,
         request.assignee ?? null, creator, request.startDate ?? null, request.dueDate ?? null,
         request.recurrence === undefined ? null : json(request.recurrence), request.workflowId ?? null,
@@ -431,7 +437,7 @@ export class SqliteTaskboardProvider {
       )
       this.sql('UPDATE projects SET next_issue_number = next_issue_number + 1, version = version + 1, updated_at = ? WHERE id = ?')
         .run(timestamp, request.projectId)
-      this.activity(taskId, 'task.created', actor, undefined, { identifier, status: request.status ?? 'backlog' }, timestamp)
+      this.activity(taskId, 'task.created', actor, undefined, { identifier, status }, timestamp)
       this.bumpRevision()
     })
     return this.getTask(taskId)
@@ -476,7 +482,8 @@ export class SqliteTaskboardProvider {
     this.getProject(filter.projectId)
     const clauses = ['project_id = ?']
     const values: SqlValue[] = [filter.projectId]
-    if (filter.includeArchived !== true) clauses.push('archived_at IS NULL')
+    if (filter.archivedOnly === true) clauses.push('archived_at IS NOT NULL')
+    else if (filter.includeArchived !== true) clauses.push('archived_at IS NULL')
     if (filter.statuses !== undefined && filter.statuses.length > 0) {
       clauses.push(`status IN (${filter.statuses.map(() => '?').join(',')})`)
       values.push(...filter.statuses)
@@ -561,23 +568,7 @@ export class SqliteTaskboardProvider {
       if (this.activeClaimRow(taskId) !== undefined) {
         throw new TaskboardError('task already has an active claim', 'TASK_ALREADY_CLAIMED', { taskId })
       }
-      if (current.developmentContext !== undefined
-        && !(current.developmentContext.kind === 'worktree' && this.attachmentOptions.allowSharedWorktrees)) {
-        const conflict = this.sql(`
-          SELECT tasks.identifier
-          FROM task_claims claims JOIN tasks ON tasks.id = claims.task_id
-          WHERE claims.state IN ('active','orphaned') AND claims.task_id <> ?
-            AND claims.development_context_json = ?
-          ORDER BY claims.claimed_at LIMIT 1
-        `).get(taskId, json(current.developmentContext)) as Row | undefined
-        if (conflict !== undefined) {
-          throw new TaskboardError(
-            `development context is already owned by ${String(conflict['identifier'])}`,
-            'TASK_DEVELOPMENT_CONTEXT_BUSY',
-            { task: conflict['identifier'] },
-          )
-        }
-      }
+      this.assertDevelopmentContextFree(taskId, current.developmentContext)
       const dependency = this.sql(`
         SELECT dependency.identifier, dependency.status
         FROM task_relations relation
@@ -686,6 +677,11 @@ export class SqliteTaskboardProvider {
       if (current.status === target && sortOrder === undefined) {
         throw new TaskboardError('task update contains no fields', 'TASK_INVALID_INPUT')
       }
+      // A board drag creates no claim, so nothing used to stop a card from entering an exclusive
+      // branch or worktree that an Agent is already working in.
+      if (target === 'in_progress' && current.status !== 'in_progress') {
+        this.assertDevelopmentContextFree(taskId, current.developmentContext)
+      }
       const timestamp = now()
       if (current.status === 'in_progress' && target !== 'in_progress') {
         this.sql("UPDATE task_claims SET state = 'released', updated_at = ? WHERE task_id = ? AND state IN ('active','orphaned')")
@@ -708,7 +704,12 @@ export class SqliteTaskboardProvider {
     return this.transaction(() => {
       const current = this.mutableTask(taskId, expectedVersion)
       requireStatus(current.status, ['todo', 'in_progress'], 'block')
-      if (actor.kind !== 'human' && current.status === 'in_progress') this.assertOwningClaim(taskId, actor)
+      if (actor.kind !== 'human') {
+        // A `todo` has no owner, so this let any Session with the tool blank out a whole column of
+        // work it had never claimed. Blocking a todo stays a human decision.
+        requireStatus(current.status, ['in_progress'], 'Agent block')
+        this.assertOwningClaim(taskId, actor)
+      }
       const timestamp = now()
       this.insertComment(taskId, `Blocked: ${body}`, actor, timestamp)
       this.writeStatus(taskId, expectedVersion, 'blocked', timestamp)
@@ -1400,6 +1401,7 @@ export class SqliteTaskboardProvider {
     if (this.activeClaimRow(taskId) !== undefined) {
       throw new TaskboardError('task already has an active claim', 'TASK_ALREADY_CLAIMED', { taskId })
     }
+    this.assertDevelopmentContextFree(taskId, developmentContext)
     const claimId = ClaimId(id('claim'))
     this.sql(`
       INSERT INTO task_claims(id, task_id, session_id, agent_id, automation_id, expected_task_version, state, development_context_json, claimed_at, updated_at)
@@ -1490,6 +1492,36 @@ export class SqliteTaskboardProvider {
       cursor = row === undefined ? undefined : TaskId(String(row['target_task_id']))
     }
     return false
+  }
+
+  /** Reject a second owner on an exclusive branch or worktree.
+   *  Two rows can hold one context: a live claim, and a task a human moved into `in_progress`
+   *  without any claim at all. Both used to be invisible to every path except `claim()`. */
+  private assertDevelopmentContextFree(taskId: TaskboardTaskId, context: DevelopmentContext | undefined): void {
+    if (context === undefined) return
+    if (context.kind === 'worktree' && this.attachmentOptions.allowSharedWorktrees) return
+    const encoded = json(context)
+    const conflict = this.sql(`
+      SELECT tasks.identifier
+      FROM tasks
+      WHERE tasks.id <> ?
+        AND (
+          (tasks.status = 'in_progress' AND tasks.development_context_json = ?)
+          OR EXISTS (
+            SELECT 1 FROM task_claims claims
+            WHERE claims.task_id = tasks.id AND claims.state IN ('active','orphaned')
+              AND claims.development_context_json = ?
+          )
+        )
+      ORDER BY tasks.identifier LIMIT 1
+    `).get(taskId, encoded, encoded) as Row | undefined
+    if (conflict !== undefined) {
+      throw new TaskboardError(
+        `development context is already owned by ${String(conflict['identifier'])}`,
+        'TASK_DEVELOPMENT_CONTEXT_BUSY',
+        { task: conflict['identifier'] },
+      )
+    }
   }
 
   private validateDevelopmentContext(context: DevelopmentContext | null | undefined): void {

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -120,7 +120,7 @@ export function taskboardToolDefinitions(service: TaskboardService): ToolDefinit
     }),
     defineTool({
       name: 'taskboard_block',
-      description: 'Block an eligible todo or the owning in-progress claim with a concrete non-empty reason and exact current version.',
+      description: 'Block the in-progress task this Session owns, with a concrete non-empty reason and exact current version. A todo you have not claimed can only be blocked by a human.',
       parameters: {
         task_id: { type: 'string', required: true },
         expected_version: { type: 'integer', required: true },

--- a/tests/attachment-routes.spec.ts
+++ b/tests/attachment-routes.spec.ts
@@ -121,3 +121,53 @@ test('a download ticket streams a larger attachment and refuses a corrupted stor
     rmSync(directory, { recursive: true, force: true })
   }
 })
+
+test('a wrong method is rejected without spending the one-time ticket', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'dsh-taskboard-method-'))
+  const provider = new SqliteTaskboardProvider(join(directory, 'taskboard.sqlite'), {
+    root: join(directory, 'attachments'), maxAttachmentBytes: 64, maxTaskAttachmentBytes: 128,
+    allowedContentTypes: ['text/plain'], allowSharedWorktrees: false,
+  })
+  const human = { kind: 'human' as const, actorId: 'web-user' }
+  let handler: ((request: IncomingMessage, response: ServerResponse) => void | Promise<void>) | undefined
+  const routes = new TaskboardAttachmentRoutes(provider)
+  routes.mount({ register(route: { handler: typeof handler }) { handler = route.handler; return () => undefined } } as never)
+  try {
+    const project = provider.createProject({ key: 'DSH', name: 'Harness' }, human)
+    const task = provider.createTask({ projectId: project.id, title: 'Bytes', creator: human.actorId }, human)
+    const upload = routes.issueUpload({
+      taskId: task.id, expectedVersion: task.version, filename: 'proof.txt', contentType: 'text/plain',
+    }, human)
+
+    // A stray GET, or a preflight OPTIONS from a proxy, used to consume the capability before the
+    // method was ever checked, so the client had to mint a new ticket against a newer version.
+    const wrongMethod = responseCapture()
+    await handler!(request('GET', upload.url), wrongMethod.response)
+    assert.equal(wrongMethod.read().status, 405)
+    const preflight = responseCapture()
+    await handler!(request('OPTIONS', upload.url), preflight.response)
+    assert.equal(preflight.read().status, 405)
+
+    const accepted = responseCapture()
+    await handler!(request('PUT', upload.url, new TextEncoder().encode('verified')), accepted.response)
+    assert.equal(accepted.read().status, 201)
+    assert.equal(provider.getTaskDetail(task.id).attachments.length, 1)
+
+    // Still single use once it is actually spent.
+    const replay = responseCapture()
+    await handler!(request('PUT', upload.url, new TextEncoder().encode('again')), replay.response)
+    assert.equal(replay.read().status, 404)
+
+    const download = routes.issueDownload(provider.getTaskDetail(task.id).attachments[0]!.id, 'attachment')
+    const wrongDownload = responseCapture()
+    await handler!(request('POST', download.url), wrongDownload.response)
+    assert.equal(wrongDownload.read().status, 405)
+    const streamed = responseCapture()
+    await handler!(request('GET', download.url), streamed.response)
+    assert.equal(streamed.read().status, 200)
+    assert.equal(streamed.read().body.toString(), 'verified')
+  } finally {
+    provider.close()
+    rmSync(directory, { recursive: true, force: true })
+  }
+})

--- a/tests/automation.spec.ts
+++ b/tests/automation.spec.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { Context } from '@deepseek-ai/cordis'
 import { TaskboardAutomationCoordinator } from '../src/automation/index.js'
+import { TaskboardError } from '../src/domain/index.js'
 import { TaskboardService } from '../src/service/index.js'
 import type { AutomationRule, AutomationRuleConfig, HumanActor, TaskboardTask } from '../src/domain/index.js'
 
@@ -321,6 +322,124 @@ test('immediate run keeps the original timer so the scheduled tick still fires',
     await new Promise(resolve => { setTimeout(resolve, Math.max(50, scheduledAt - Date.now() + 80)) })
     assert.deepEqual(started, [first.id, second.id])
     assert.equal(service.provider.getTask(second.id).status, 'in_progress')
+    await coordinator.stop()
+  } finally {
+    service.provider.close()
+  }
+})
+
+test('a candidate whose development context is busy leaves the rest of the queue claimable', async () => {
+  const service = new TaskboardService(new Context(), { databasePath: ':memory:', attachmentRoot: '.dsh/test' })
+  try {
+    const project = service.provider.createProject({ key: 'DSH', name: 'Harness' }, human)
+    const shared = { kind: 'branch', branch: 'feature/shared' } as const
+    const first = service.provider.createTask({
+      projectId: project.id, title: 'First', creator: human.actorId, status: 'todo', developmentContext: shared,
+    }, human)
+    const blocked = service.provider.createTask({
+      projectId: project.id, title: 'Shares the branch', creator: human.actorId, status: 'todo', developmentContext: shared,
+    }, human)
+    const independent = service.provider.createTask({
+      projectId: project.id, title: 'Independent', creator: human.actorId, status: 'todo',
+    }, human)
+    let rule = service.provider.createAutomation(project.id, { ...config, concurrencyLimit: 3 }, human)
+    rule = service.provider.updateAutomation(rule.id, rule.version, { state: 'enabled' }, human)
+    const started: string[] = []
+    const coordinator = new TaskboardAutomationCoordinator(service, owningWorker(service, started))
+    await coordinator.runNow(rule.id)
+    // Contention on one candidate used to throw out of the whole drain, so every todo behind it
+    // waited for the next interval.
+    assert.deepEqual([...started].sort(), [first.id, independent.id].sort())
+    assert.equal(service.provider.getTask(blocked.id).status, 'todo')
+    const latest = service.provider.getAutomation(rule.id)
+    assert.equal(latest.state, 'enabled')
+    assert.equal(latest.lastDecision?.kind, 'empty')
+    assert.match(latest.lastDecision?.message ?? '', /already owned elsewhere/)
+    assert.ok(latest.nextEligibleAt !== undefined)
+    await coordinator.stop()
+  } finally {
+    service.provider.close()
+  }
+})
+
+test('every claim contention code skips its candidate instead of ending the round', async () => {
+  for (const code of ['TASK_INVALID_TRANSITION', 'TASK_ALREADY_CLAIMED', 'TASK_STALE_VERSION', 'TASK_DEVELOPMENT_CONTEXT_BUSY'] as const) {
+    const service = new TaskboardService(new Context(), { databasePath: ':memory:', attachmentRoot: '.dsh/test' })
+    try {
+      const project = service.provider.createProject({ key: 'DSH', name: 'Harness' }, human)
+      const contended = service.provider.createTask({ projectId: project.id, title: 'Taken', creator: human.actorId, status: 'todo' }, human)
+      const free = service.provider.createTask({ projectId: project.id, title: 'Free', creator: human.actorId, status: 'todo' }, human)
+      let rule = service.provider.createAutomation(project.id, { ...config, concurrencyLimit: 2 }, human)
+      rule = service.provider.updateAutomation(rule.id, rule.version, { state: 'enabled' }, human)
+      const started: string[] = []
+      const owning = owningWorker(service, started)
+      const coordinator = new TaskboardAutomationCoordinator(service, {
+        start(activeRule: AutomationRule, candidate: TaskboardTask) {
+          if (candidate.id === contended.id) throw new TaskboardError(`simulated ${code}`, code)
+          return owning.start(activeRule, candidate)
+        },
+      })
+      await coordinator.runNow(rule.id)
+      assert.deepEqual(started, [free.id], code)
+      assert.equal(service.provider.getAutomation(rule.id).state, 'enabled', code)
+      await coordinator.stop()
+    } finally {
+      service.provider.close()
+    }
+  }
+})
+
+test('worker failure bookkeeping never fails the drain that awaits it', async () => {
+  const service = new TaskboardService(new Context(), { databasePath: ':memory:', attachmentRoot: '.dsh/test' })
+  try {
+    const project = service.provider.createProject({ key: 'DSH', name: 'Harness' }, human)
+    const tasks = [1, 2, 3].map(number => service.provider.createTask({
+      projectId: project.id, title: `Task ${number}`, creator: human.actorId, status: 'todo',
+    }, human))
+    let rule = service.provider.createAutomation(project.id, { ...config, concurrencyLimit: 3 }, human)
+    rule = service.provider.updateAutomation(rule.id, rule.version, { state: 'enabled' }, human)
+    const coordinator = new TaskboardAutomationCoordinator(service, {
+      async start(activeRule: AutomationRule, candidate: TaskboardTask) {
+        const sessionId = `automation-${candidate.id}`
+        service.provider.claim(candidate.id, {
+          expectedVersion: candidate.version, sessionId, agentId: sessionId,
+        }, { kind: 'automation', actorId: sessionId, automationId: activeRule.id, sessionId, agentId: sessionId })
+        // Every worker fails asynchronously, so each error decision bumps the rule version while
+        // the drain is parked on an await holding the version it read before them.
+        await new Promise(resolve => { setTimeout(resolve, 5) })
+        throw new Error(`launch failed for ${candidate.identifier}`)
+      },
+    }, { state: async () => { await new Promise(resolve => { setTimeout(resolve, 20) }); return 'available' } })
+    await coordinator.runNow(rule.id)
+    assert.deepEqual(tasks.map(task => service.provider.getTask(task.id).status), ['in_progress', 'in_progress', 'in_progress'])
+    const latest = service.provider.getAutomation(rule.id)
+    assert.equal(latest.state, 'enabled')
+    assert.ok(service.provider.listAutomationRuns(project.id).some(run => run.decision.kind === 'error'))
+    await coordinator.stop()
+  } finally {
+    service.provider.close()
+  }
+})
+
+test('a thrown drain still re-arms the durable timer', async () => {
+  const service = new TaskboardService(new Context(), { databasePath: ':memory:', attachmentRoot: '.dsh/test' })
+  try {
+    const project = service.provider.createProject({ key: 'DSH', name: 'Harness' }, human)
+    service.provider.createTask({ projectId: project.id, title: 'Only', creator: human.actorId, status: 'todo' }, human)
+    let rule = service.provider.createAutomation(project.id, config, human)
+    rule = service.provider.updateAutomation(rule.id, rule.version, { state: 'enabled' }, human)
+    const coordinator = new TaskboardAutomationCoordinator(service, {
+      start: () => { throw new Error('unexpected worker fault') },
+    })
+    coordinator.start()
+    await coordinator.runNow(rule.id)
+    // The tick cancels the timer on entry, so a genuine fault used to leave the rule unscheduled
+    // until a rescan or a Host restart.
+    const latest = service.provider.getAutomation(rule.id)
+    assert.equal(latest.state, 'enabled')
+    assert.equal(latest.lastDecision?.kind, 'error')
+    assert.match(latest.lastDecision?.message ?? '', /unexpected worker fault/)
+    assert.ok((latest.nextEligibleAt ?? 0) > Date.now())
     await coordinator.stop()
   } finally {
     service.provider.close()

--- a/tests/cli.spec.ts
+++ b/tests/cli.spec.ts
@@ -126,3 +126,32 @@ test('CLI round-trips project, task, relation, attachment, workflow, automation,
   second = invoke(['task', 'archive', '--task', second.id, '--version', String(second.version)]) as typeof second
   invoke(['task', 'delete', '--task', second.id, '--version', String(second.version)])
 })
+
+test('CLI task creation refuses a status the lifecycle does not own', t => {
+  const directory = mkdtempSync(join(tmpdir(), 'dsh-taskboard-status-'))
+  t.after(() => { rmSync(directory, { recursive: true, force: true }) })
+  const database = join(directory, 'taskboard.sqlite')
+  const cli = (args: string[]): { code: number; stdout: string; stderr: string } => {
+    let stdout = ''
+    let stderr = ''
+    const code = runTaskboardCli(['--database', database, ...args], {
+      stdout: value => { stdout += value },
+      stderr: value => { stderr += value },
+    })
+    return { code, stdout, stderr }
+  }
+  const project = JSON.parse(cli(['project', 'create', '--key', 'DSH', '--name', 'Harness']).stdout).value as { id: string }
+
+  // A cast used to be the only gate on the flag, and --request-json had no second check at all.
+  const flagged = cli(['task', 'create', '--project', project.id, '--title', 'Smuggled', '--status', 'done'])
+  assert.notEqual(flagged.code, 0)
+  assert.match(flagged.stderr, /TASK_INVALID_INPUT/)
+  const payload = cli(['task', 'create', '--request-json', JSON.stringify({
+    projectId: project.id, title: 'Smuggled again', creator: 'cli', status: 'done',
+  })])
+  assert.notEqual(payload.code, 0)
+  assert.match(payload.stderr, /TASK_INVALID_INPUT/)
+
+  assert.equal(cli(['task', 'create', '--project', project.id, '--title', 'Allowed', '--status', 'todo']).code, 0)
+  assert.equal((JSON.parse(cli(['task', 'list', '--project', project.id]).stdout).value as unknown[]).length, 1)
+})

--- a/tests/client-route.spec.ts
+++ b/tests/client-route.spec.ts
@@ -142,7 +142,15 @@ test('client change watch uses the plugin Remote carrier and preserves revision 
   )
   assert.deepEqual(await controller.watchChanges(6), { globalRevision: 7, changed: true })
   assert.equal(request?.endpoint, 'changes.watch')
-  assert.deepEqual(JSON.parse(request?.payloadJson ?? 'null'), { afterRevision: 6, timeoutMs: 10_000 })
+  const payload = JSON.parse(request?.payloadJson ?? 'null') as { afterRevision: number; timeoutMs: number; watcherId: string }
+  assert.equal(payload.afterRevision, 6)
+  assert.equal(payload.timeoutMs, 10_000)
+  // The watcher id lets the Host release the waiter this page abandons on abort, so it has to be
+  // present and stable for the life of the controller.
+  assert.equal(typeof payload.watcherId, 'string')
+  assert.ok(payload.watcherId.length > 0)
+  await controller.watchChanges(7)
+  assert.equal((JSON.parse(request?.payloadJson ?? 'null') as { watcherId: string }).watcherId, payload.watcherId)
 })
 
 test('explicit new Session creation carries an unsent task draft and returns the native Session id', async () => {

--- a/tests/execution.spec.ts
+++ b/tests/execution.spec.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { Context } from '@deepseek-ai/cordis'
 import type { Message } from '@deepseek-ai/dsh-llm'
+import { TaskboardError } from '../src/domain/index.js'
 import type { HumanActor } from '../src/domain/index.js'
 import { completionResultComment, HarnessTaskboardWorker } from '../src/execution/index.js'
 import { TaskboardService } from '../src/service/index.js'
@@ -256,4 +257,117 @@ test('native worker fails loudly when Host default model is missing and modelRou
 test('goal completion writes a result comment and does not copy existing comments', () => {
   assert.equal(completionResultComment([]), 'Work completed.')
   assert.equal(completionResultComment([{ body: 'Implemented the endpoint.' }]), 'Ready for review.')
+})
+
+test('human comments on a claimed task reach the owning Session, and a blank Goal blocker is survivable', async () => {
+  const ctx = new Context()
+  const service = new TaskboardService(ctx, { databasePath: ':memory:', attachmentRoot: '.dsh/test' })
+  const messages: Message[] = []
+  let activeAgent: { id: string; followup(message: Message): void; whenIdle(): Promise<void> } | undefined
+  ctx.provide('agentPresets', { mount: async () => undefined } as never)
+  provideDefaultModel(ctx)
+  ctx.provide('workspaceRegistry', { get: () => ({ path: '/workspace/project', attachSession: async () => undefined }) } as never)
+  ctx.provide('goals', { get: () => undefined, create: () => ({ id: 'goal-1' }) } as never)
+  ctx.provide('agents', {
+    list: () => activeAgent === undefined ? [] : [{ id: activeAgent.id }],
+    create: async (options: { sessionId: string; setup(context: Context): Promise<void> }) => {
+      await options.setup(new Context())
+      activeAgent = { id: options.sessionId, followup: message => { messages.push(message) }, whenIdle: () => Promise.resolve() }
+      return { agent: activeAgent, dispose: () => Promise.resolve() }
+    },
+    resume: async () => { throw new Error('unexpected resume') },
+  } as never)
+
+  try {
+    const project = service.provider.createProject({ key: 'DSH', name: 'Harness', workspaceId: 'workspace-1' }, human)
+    let task = service.provider.createTask({ projectId: project.id, title: 'Commented', creator: human.actorId }, human)
+    task = service.provider.approve(task.id, task.version, human)
+    const rule = service.provider.createAutomation(project.id, {
+      intervalMs: 30_000, agentPreset: 'coding', concurrencyLimit: 1,
+      quotaPolicy: 'pause-on-uncertain', autoPauseOnEmpty: false,
+    }, human)
+    const worker = new HarnessTaskboardWorker(ctx, service)
+    await worker.start(rule, task)
+    // One message so far: the initial instruction.
+    assert.equal(messages.length, 1)
+
+    // The provider writes `comment.created` / `comment.updated`; the listener used to test for a
+    // `task.commented` kind that nothing emits, so human comments never reached the Session.
+    const claimed = service.provider.getTask(task.id)
+    service.provider.comment(claimed.id, claimed.version, 'Also cover the blank-input case.', human)
+    assert.equal(messages.length, 2)
+    assert.match(messages[1]?.content[0]?.type === 'text' ? messages[1].content[0].text : '', /changed after your claim/)
+    assert.match(messages[1]?.content[0]?.type === 'text' ? messages[1].content[0].text : '', /Also cover the blank-input case/)
+
+    const commentId = service.provider.getTaskDetail(task.id).comments.at(-1)?.id ?? ''
+    const beforeEdit = service.provider.getTask(task.id)
+    service.provider.updateComment(beforeEdit.id, beforeEdit.version, commentId, 'Cover the whitespace case instead.', human)
+    assert.equal(messages.length, 3)
+    assert.match(messages[2]?.content[0]?.type === 'text' ? messages[2].content[0].text : '', /whitespace case/)
+
+    // A Goal can report a blank reason. `requiredText` used to throw that straight out of the Host
+    // event dispatch, leaving the task in progress and the Session handle held.
+    assert.ok(activeAgent)
+    ;(worker as unknown as { onGoalChanged(agent: unknown, goal: unknown): void }).onGoalChanged(activeAgent, {
+      id: 'goal-1', phase: 'blocked', objective: 'blocked task', blockedReason: { message: '   ' }, createdAt: 1, updatedAt: 2,
+    })
+    assert.equal(service.provider.getTask(task.id).status, 'blocked')
+    assert.match(service.provider.getTaskDetail(task.id).comments.at(-1)?.body ?? '', /Blocked: Harness Goal blocked/)
+    await worker.stop()
+  } finally {
+    service.provider.close()
+  }
+})
+
+test('a Goal that outlives its claim records the failure instead of throwing at the Host', async () => {
+  const ctx = new Context()
+  const service = new TaskboardService(ctx, { databasePath: ':memory:', attachmentRoot: '.dsh/test' })
+  let activeAgent: { id: string; followup(): void; whenIdle(): Promise<void> } | undefined
+  ctx.provide('agentPresets', { mount: async () => undefined } as never)
+  provideDefaultModel(ctx)
+  ctx.provide('workspaceRegistry', { get: () => ({ path: '/workspace/project', attachSession: async () => undefined }) } as never)
+  ctx.provide('goals', { get: () => undefined, create: () => ({ id: 'goal-1' }) } as never)
+  ctx.provide('agents', {
+    list: () => activeAgent === undefined ? [] : [{ id: activeAgent.id }],
+    create: async (options: { sessionId: string; setup(context: Context): Promise<void> }) => {
+      await options.setup(new Context())
+      activeAgent = { id: options.sessionId, followup: () => undefined, whenIdle: () => Promise.resolve() }
+      return { agent: activeAgent, dispose: () => Promise.resolve() }
+    },
+    resume: async () => { throw new Error('unexpected resume') },
+  } as never)
+
+  try {
+    const project = service.provider.createProject({ key: 'DSH', name: 'Harness', workspaceId: 'workspace-1' }, human)
+    let task = service.provider.createTask({ projectId: project.id, title: 'Raced', creator: human.actorId }, human)
+    task = service.provider.approve(task.id, task.version, human)
+    const rule = service.provider.createAutomation(project.id, {
+      intervalMs: 30_000, agentPreset: 'coding', concurrencyLimit: 1,
+      quotaPolicy: 'pause-on-uncertain', autoPauseOnEmpty: false,
+    }, human)
+    const worker = new HarnessTaskboardWorker(ctx, service)
+    await worker.start(rule, task)
+    assert.ok(activeAgent)
+    // Force the mutation to fail the way a cross-process write would: the version the listener
+    // reads no longer matches by the time it writes.
+    const patched = service.provider as unknown as { submitReview(...args: unknown[]): unknown }
+    const original = patched.submitReview.bind(service.provider)
+    patched.submitReview = () => { throw new TaskboardError('task version changed during transition', 'TASK_STALE_VERSION') }
+    try {
+      ;(worker as unknown as { onGoalChanged(agent: unknown, goal: unknown): void }).onGoalChanged(activeAgent, {
+        id: 'goal-1', phase: 'complete', objective: 'done task', createdAt: 1, updatedAt: 2,
+      })
+    } finally {
+      patched.submitReview = original
+    }
+    const runs = service.provider.listAutomationRuns(project.id)
+    assert.ok(runs.some(run => run.decision.kind === 'error' && /Goal handoff failed/.test(run.decision.message)))
+    // The authoritative task is untouched and the claim survives, so the Session handle is still
+    // legitimately held; what must not happen is the domain error escaping the listener.
+    assert.equal(service.provider.getTask(task.id).status, 'in_progress')
+    assert.equal(service.provider.getTaskDetail(task.id).activeClaim?.state, 'active')
+    await worker.stop()
+  } finally {
+    service.provider.close()
+  }
 })

--- a/tests/service.spec.ts
+++ b/tests/service.spec.ts
@@ -400,3 +400,79 @@ test('the integrity scan is explicit and never rides along on a snapshot', () =>
     service.provider.close()
   }
 })
+
+test('archived work is budgeted apart from the live board and stays searchable past the limit', async () => {
+  const ctx = new Context()
+  const service = new TaskboardService(ctx, { ...config, snapshotTaskLimit: 3 })
+  const actor = { kind: 'human', actorId: 'test-human' } as const
+  try {
+    const project = service.provider.createProject({ key: 'DSH', name: 'Harness' }, actor)
+    for (let index = 0; index < 4; index += 1) {
+      const task = service.provider.createTask({ projectId: project.id, title: `Archived ${index}`, creator: 'test-human' }, actor)
+      service.provider.archive(task.id, task.version, actor)
+    }
+    const live = [0, 1, 2].map(index => service.provider.createTask({
+      projectId: project.id, title: `Live ${index}`, creator: 'test-human',
+    }, actor))
+    const needle = service.provider.createTask({ projectId: project.id, title: 'Findable needle', creator: 'test-human' }, actor)
+
+    // One shared budget let a large archive push every live card out of the snapshot and leave
+    // nothing but a truncation notice on the board.
+    const snapshot = service.snapshot(project.id)
+    assert.equal(snapshot.tasks.filter(task => task.archivedAt === undefined).length, 3)
+    assert.equal(snapshot.tasks.filter(task => task.archivedAt !== undefined).length, 4)
+    assert.equal(snapshot.taskTotal, 8)
+    assert.equal(snapshot.tasksTruncated, true)
+    assert.ok(live.every(task => snapshot.tasks.some(row => row.id === task.id)))
+
+    // The board filters in memory, so anything past the limit is only reachable through SQLite.
+    assert.equal(snapshot.tasks.some(task => task.id === needle.id), false)
+    const found = service.dispatchHumanRpc('task.search', { projectId: project.id, search: 'needle' }, actor)
+    assert.equal(found.ok, true)
+    if (!found.ok) return
+    assert.deepEqual((found.value as Array<{ id: string }>).map(task => task.id), [needle.id])
+  } finally {
+    service.provider.close()
+  }
+})
+
+test('the Typert mutation carrier reports the domain code, not a flattened internal', async () => {
+  const ctx = new Context()
+  const service = new TaskboardService(ctx, config)
+  try {
+    const result = await service.remoteMutate({
+      endpoint: 'task.accept',
+      payloadJson: JSON.stringify({ taskId: 'missing', expectedVersion: 1 }),
+    })
+    assert.equal(result.ok, false)
+    if (result.ok) return
+    // Callers that switch on the code used to see every conflict, validation error, and genuine
+    // fault as the same `internal`.
+    assert.equal(result.errorCode, 'TASK_NOT_FOUND')
+    assert.equal(result.errorMessage, 'task missing was not found')
+  } finally {
+    service.provider.close()
+  }
+})
+
+test('a replacement change watch releases the waiter its page abandoned', async () => {
+  const ctx = new Context()
+  const service = new TaskboardService(ctx, { ...config, maxChangeWaiters: 2 })
+  try {
+    const revision = service.provider.globalRevision()
+    // An abort is local to the browser and never reaches the Host, so without the watcher id the
+    // abandoned poll held its slot for the whole timeout and a refresh loop filled the pool.
+    const abandoned = service.watchChanges(revision, 30_000, 'page-1')
+    const replacement = service.watchChanges(revision, 30_000, 'page-1')
+    assert.deepEqual(await abandoned, { globalRevision: revision, changed: false })
+
+    const other = service.watchChanges(revision, 30_000, 'page-2')
+    assert.throws(() => service.watchChanges(revision, 30_000, 'page-3'))
+
+    service.provider.createProject({ key: 'DSH', name: 'Harness' }, { kind: 'human', actorId: 'test-human' })
+    assert.equal((await replacement).changed, true)
+    assert.equal((await other).changed, true)
+  } finally {
+    service.provider.close()
+  }
+})

--- a/tests/sqlite-provider.spec.ts
+++ b/tests/sqlite-provider.spec.ts
@@ -538,3 +538,141 @@ test('countTasks reports totals independently of the requested page', () => {
     provider.close()
   }
 })
+
+test('task creation refuses a status outside the reviewable entry points', () => {
+  const provider = memoryProvider()
+  try {
+    const project = provider.createProject({ key: 'DSH', name: 'Harness' }, human)
+    // The table CHECK accepts all seven statuses, so nothing but this guard stops an RPC or CLI
+    // payload from opening a task straight at done and skipping the human-owned lifecycle.
+    for (const status of ['done', 'in_progress', 'in_review', 'blocked', 'canceled'] as const) {
+      assert.throws(
+        () => provider.createTask({
+          projectId: project.id, title: 'Smuggled', creator: human.actorId, status: status as 'todo',
+        }, human),
+        (error: unknown) => error instanceof TaskboardError && error.code === 'TASK_INVALID_INPUT',
+        status,
+      )
+    }
+    assert.equal(provider.createTask({ projectId: project.id, title: 'Backlog', creator: human.actorId }, human).status, 'backlog')
+    assert.equal(provider.createTask({ projectId: project.id, title: 'Todo', creator: human.actorId, status: 'todo' }, human).status, 'todo')
+    assert.equal(provider.countTasks({ projectId: project.id }), 2)
+  } finally {
+    provider.close()
+  }
+})
+
+test('an Agent may only block the in-progress task it owns', () => {
+  const provider = memoryProvider()
+  try {
+    const project = provider.createProject({ key: 'DSH', name: 'Harness' }, human)
+    let unclaimed = provider.createTask({ projectId: project.id, title: 'Nobody owns this', creator: human.actorId }, human)
+    unclaimed = provider.approve(unclaimed.id, unclaimed.version, human)
+    // A todo column has no owner, so this used to let any Session with the tool stop work it had
+    // never claimed.
+    assert.throws(
+      () => provider.block(unclaimed.id, unclaimed.version, 'I decided this is blocked', agent),
+      (error: unknown) => error instanceof TaskboardError && error.code === 'TASK_INVALID_TRANSITION',
+    )
+    assert.equal(provider.getTask(unclaimed.id).status, 'todo')
+
+    const claimed = provider.claim(unclaimed.id, {
+      expectedVersion: unclaimed.version, sessionId: agent.sessionId, agentId: agent.agentId,
+    }, agent)
+    assert.throws(
+      () => provider.block(claimed.task.id, claimed.task.version, 'not my claim', otherAgent),
+      (error: unknown) => error instanceof TaskboardError && error.code === 'TASK_FOREIGN_CLAIM',
+    )
+    const blocked = provider.block(claimed.task.id, claimed.task.version, 'waiting on an upstream decision', agent)
+    assert.equal(blocked.status, 'blocked')
+
+    // A human still owns the todo column.
+    let humanTask = provider.createTask({ projectId: project.id, title: 'Human blocks this', creator: human.actorId }, human)
+    humanTask = provider.approve(humanTask.id, humanTask.version, human)
+    assert.equal(provider.block(humanTask.id, humanTask.version, 'blocked by policy', human).status, 'blocked')
+  } finally {
+    provider.close()
+  }
+})
+
+test('an exclusive development context admits one owner across every entry point', () => {
+  const provider = memoryProvider()
+  try {
+    const project = provider.createProject({ key: 'DSH', name: 'Harness' }, human)
+    const context = { kind: 'branch', branch: 'feature/exclusive' } as const
+    let owned = provider.createTask({
+      projectId: project.id, title: 'Owned', creator: human.actorId, developmentContext: context,
+    }, human)
+    owned = provider.approve(owned.id, owned.version, human)
+    provider.claim(owned.id, { expectedVersion: owned.version, sessionId: agent.sessionId, agentId: agent.agentId }, agent)
+
+    let rival = provider.createTask({
+      projectId: project.id, title: 'Rival', creator: human.actorId, developmentContext: context,
+    }, human)
+    rival = provider.approve(rival.id, rival.version, human)
+    // A board drag creates no claim, so nothing used to stop a card from entering a branch an
+    // Agent was already working in.
+    assert.throws(
+      () => provider.moveStatus(rival.id, rival.version, 'in_progress', human),
+      (error: unknown) => error instanceof TaskboardError && error.code === 'TASK_DEVELOPMENT_CONTEXT_BUSY',
+    )
+    assert.equal(provider.getTask(rival.id).status, 'todo')
+    assert.throws(
+      () => provider.claim(rival.id, { expectedVersion: rival.version, sessionId: 'session-3', agentId: 'agent-3' }, {
+        kind: 'agent', actorId: 'agent-3', sessionId: 'session-3', agentId: 'agent-3',
+      }),
+      (error: unknown) => error instanceof TaskboardError && error.code === 'TASK_DEVELOPMENT_CONTEXT_BUSY',
+    )
+
+    // The reverse order is now covered too: an owner-less in_progress card holds the context.
+    const released = provider.getTask(owned.id)
+    provider.releaseClaim(released.id, released.version, 'handing back', agent)
+    const moved = provider.moveStatus(rival.id, provider.getTask(rival.id).version, 'in_progress', human)
+    assert.equal(moved.status, 'in_progress')
+    assert.equal(provider.getTaskDetail(moved.id).activeClaim, undefined)
+    assert.throws(
+      () => provider.claim(released.id, { expectedVersion: provider.getTask(released.id).version, sessionId: 'session-4', agentId: 'agent-4' }, {
+        kind: 'agent', actorId: 'agent-4', sessionId: 'session-4', agentId: 'agent-4',
+      }),
+      (error: unknown) => error instanceof TaskboardError && error.code === 'TASK_DEVELOPMENT_CONTEXT_BUSY',
+    )
+  } finally {
+    provider.close()
+  }
+})
+
+test('rework and resume into in-progress refuse a busy development context', () => {
+  const provider = memoryProvider()
+  try {
+    const project = provider.createProject({ key: 'DSH', name: 'Harness' }, human)
+    const context = { kind: 'branch', branch: 'feature/rework' } as const
+    let submitted = provider.createTask({
+      projectId: project.id, title: 'In review', creator: human.actorId, developmentContext: context,
+    }, human)
+    submitted = provider.approve(submitted.id, submitted.version, human)
+    const claim = provider.claim(submitted.id, {
+      expectedVersion: submitted.version, sessionId: agent.sessionId, agentId: agent.agentId,
+    }, agent)
+    const inReview = provider.submitReview(claim.task.id, claim.task.version, 'Completed', 'Ready', agent)
+
+    // A second task takes the branch while the first sits in review.
+    let rival = provider.createTask({
+      projectId: project.id, title: 'Rival', creator: human.actorId, developmentContext: context,
+    }, human)
+    rival = provider.approve(rival.id, rival.version, human)
+    provider.claim(rival.id, { expectedVersion: rival.version, sessionId: otherAgent.sessionId, agentId: otherAgent.agentId }, otherAgent)
+
+    // `insertFreshClaim` only ever checked this task's own claims, never the shared context.
+    assert.throws(
+      () => provider.returnForRework(inReview.id, inReview.version, 'in_progress', 'please redo the edge case', human, {
+        sessionId: 'session-5', agentId: 'agent-5',
+      }),
+      (error: unknown) => error instanceof TaskboardError && error.code === 'TASK_DEVELOPMENT_CONTEXT_BUSY',
+    )
+    assert.equal(provider.getTask(inReview.id).status, 'in_review')
+    const returned = provider.returnForRework(inReview.id, inReview.version, 'todo', 'please redo the edge case', human)
+    assert.equal(returned.status, 'todo')
+  } finally {
+    provider.close()
+  }
+})


### PR DESCRIPTION
…e remaining lifecycle holes

Contended claims no longer abort a scheduler round, in-progress Sessions follow real comment activity, and admission, attachments, and the Client snapshot no longer skip exclusive context, burn one-time tickets, or hide work past the live-page budget.