### PR TITLE
ci: require checks before merging into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/setup@v1
+        with:
+          runtime: node@22
+          cache: true
+          install: false
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm check
+      - run: pnpm example

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ onlyBuiltDependencies:
 
 confirmModulesPurge: false
 allowBuilds:
-  esbuild: set this to true or false
+  esbuild: true
 minimumReleaseAgeExclude:
   - '@deepseek-ai/cordis-plugin-include@1.0.6'
   - '@deepseek-ai/cordis-plugin-loader@1.0.2'


### PR DESCRIPTION
## Summary
- Add a GitHub Actions `check` job that runs `pnpm check` and `pnpm example` on pull requests and pushes to `main`.
- Approve esbuild's install script so the client bundle can build on a clean runner.

After this workflow has run once, the Protect main ruleset will require the `check` status before a PR can merge.

## Test plan
- [ ] Confirm the `check` job passes on this PR
- [ ] Confirm the Protect main ruleset lists `check` as a required status check
- [ ] Confirm a PR cannot merge while `check` is failing or pending


Made with [Cursor](https://cursor.com)